### PR TITLE
fix(client): move webhook auth check to request time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ openssl rand -base64 32
 npx convex env set REVENUECAT_WEBHOOK_AUTH "your-generated-secret"
 ```
 
-The component throws at module load if the secret is missing or, after stripping any `Bearer ` prefix and whitespace, shorter than 32 characters. RevenueCat doesn't sign payloads, so the shared secret is the entire security boundary. Short or empty values fail the deploy rather than silently mounting an unauthenticated endpoint.
+A secret that's present but shorter than 32 characters (after stripping any `Bearer ` prefix and whitespace) throws at construction and fails the deploy. A missing secret doesn't fail the deploy. The handler rejects every webhook with a 500 until you set it. RevenueCat doesn't sign payloads, so the shared secret is the entire security boundary. An unauthenticated request is never processed.
 
 ### 4. Configure RevenueCat
 

--- a/example/convex/http.test.ts
+++ b/example/convex/http.test.ts
@@ -1,7 +1,8 @@
 /// <reference types="vite/client" />
 
-// Set BEFORE http.ts loads. `registerRoutes()` calls `httpHandler()` which
-// throws on a missing or short secret at module load.
+// Set BEFORE http.ts loads. A present-but-short or malformed secret throws
+// at construction. A missing secret is rejected per-request at runtime. The
+// auth tests below need a valid configured secret.
 const TEST_SECRET = "kZ9tQ1xH8mF3vR7yL2nP5sJ6cW0bD4gE8aT1iU4oY3w=";
 process.env.REVENUECAT_WEBHOOK_AUTH = TEST_SECRET;
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -936,20 +936,26 @@ export class RevenueCat {
         ? undefined
         : (this.options.redactPayload ?? defaultRedactPayload);
 
-    // Crash at module load when secret is missing. Fails the deploy
-    // instead of silently exposing a public mutation endpoint.
-    if (!expectedAuth) {
-      throw new Error(
-        "[convex-revenuecat] httpHandler() requires REVENUECAT_WEBHOOK_AUTH. " +
-          "Generate a secret with `openssl rand -base64 32`, set it via " +
-          "`npx convex env set REVENUECAT_WEBHOOK_AUTH <secret>`, and pass it " +
-          "as `REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH`.",
-      );
-    }
-    validateAuthSecret(expectedAuth);
-    const expectedToken = extractAuthToken(expectedAuth).trim();
-
     return httpActionGeneric(async (ctx, request) => {
+      // Validate the secret at request time, not at handler-build time. A
+      // throw during module evaluation fails Convex push analysis, which
+      // blocks component codegen: the consumer's `components.revenuecat`
+      // never leaves the `AnyComponents` stub and their app stops
+      // typechecking. Reading env at request time is the supported pattern.
+      // An unset secret rejects every webhook, so it still can't be bypassed.
+      if (!expectedAuth) {
+        console.error(
+          "[convex-revenuecat] REVENUECAT_WEBHOOK_AUTH is not set; rejecting webhook. " +
+            "Set it via `npx convex env set REVENUECAT_WEBHOOK_AUTH <secret>`.",
+        );
+        return new Response(JSON.stringify({ error: "Webhook auth not configured" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      validateAuthSecret(expectedAuth);
+      const expectedToken = extractAuthToken(expectedAuth).trim();
+
       const authHeader = request.headers.get("Authorization") ?? "";
       const providedToken = extractAuthToken(authHeader).trim();
 

--- a/src/component/audit-fixes.test.ts
+++ b/src/component/audit-fixes.test.ts
@@ -271,13 +271,29 @@ describe("audit fixes", () => {
       ).not.toThrow();
     });
 
-    test("httpHandler() throws when auth is undefined", async () => {
+    test("httpHandler() does not throw at build time when auth is undefined", async () => {
       const { RevenueCat } = await import("../client/index.js");
       // @ts-expect-error: Stub component for handler-construction test
       const rc = new RevenueCat({}, {});
-      expect(() => rc.httpHandler()).toThrow(
-        /httpHandler\(\) requires REVENUECAT_WEBHOOK_AUTH/,
-      );
+      // A build-time throw would fail Convex push analysis and block
+      // component codegen for consumers. Validation moved to request time.
+      expect(() => rc.httpHandler()).not.toThrow();
+    });
+
+    test("webhook handler rejects with 500 when auth is undefined", async () => {
+      const { RevenueCat } = await import("../client/index.js");
+      // @ts-expect-error: Stub component for handler test
+      const rc = new RevenueCat({}, {});
+      const handler = rc.httpHandler() as unknown as {
+        _handler: (ctx: unknown, request: Request) => Promise<Response>;
+      };
+      const request = new Request("https://example.convex.site/webhooks/revenuecat", {
+        method: "POST",
+        headers: { Authorization: "Bearer anything", "Content-Type": "application/json" },
+        body: JSON.stringify({ event: { id: "evt_no_secret", type: "TEST" } }),
+      });
+      const res = await handler._handler({}, request);
+      expect(res.status).toBe(500);
     });
 
     test("httpHandler() succeeds when a real secret is configured", async () => {


### PR DESCRIPTION
Move the webhook secret check out of `httpHandler()` build time and into the request handler. The build-time `throw` on a missing `REVENUECAT_WEBHOOK_AUTH` ran during Convex push analysis, so a fresh consumer's first deploy failed and `components.revenuecat` stayed typed as the `AnyComponents` stub, which made the documented `new RevenueCat(components.revenuecat, ...)` call stop typechecking until the secret was set. Reading the secret per request is the supported Convex pattern and keeps the gate intact: an unset secret now rejects every webhook with a 500 instead of crashing module load.

- `src/client/index.ts`: validate `REVENUECAT_WEBHOOK_AUTH` inside the `httpActionGeneric` handler, return 500 when unset, 401 path for bad tokens unchanged
- `src/component/audit-fixes.test.ts`: drop the build-time-throw assertion, add a no-throw-at-build check and a request-time 500 case
- `README.md`, `example/convex/http.test.ts`: describe request-time enforcement