### PR TITLE
refactor(component): align with Convex component-authoring guidelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "convex-revenuecat",
       "version": "0.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "convex-helpers": "^0.1.118"
+      },
       "devDependencies": {
         "@convex-dev/eslint-plugin": "^2.0.0",
         "@edge-runtime/vm": "^5.0.0",
@@ -210,7 +213,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -227,7 +229,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,7 +245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -261,7 +261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,7 +277,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,7 +293,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -312,7 +309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,7 +325,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -346,7 +341,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,7 +357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -380,7 +373,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -397,7 +389,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -414,7 +405,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -431,7 +421,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -448,7 +437,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -465,7 +453,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -482,7 +469,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -499,7 +485,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -516,7 +501,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -533,7 +517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -550,7 +533,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,7 +549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -584,7 +565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -601,7 +581,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,7 +597,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,7 +613,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,7 +1402,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2108,7 +2085,6 @@
       "version": "1.35.1",
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.35.1.tgz",
       "integrity": "sha512-g23KrTjBiXqRHzWIN0PVFagKjrmFxWUaOSiBsAWPTpXX2rXl0L1F4PR0YpAcMJEzMgfZR9AGymJvLTM+KA6lsQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
@@ -2139,6 +2115,40 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex-helpers": {
+      "version": "0.1.118",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.118.tgz",
+      "integrity": "sha512-07t10n8CZG/YCDzOy5/WDdNNQYL+mP7VU76BLJCZrB2dvJTH7UZJxPqNrhPH+pZbW52joQ91eQHSksdcgOXebQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "convex-helpers": "bin.cjs"
+      },
+      "peerDependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "convex": "^1.32.0",
+        "hono": "^4.0.5",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "typescript": "^5.5 || ^6.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
@@ -2238,7 +2248,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3467,7 +3476,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -3886,7 +3894,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4281,7 +4289,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4439,7 +4446,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
     "vitest": "4.1.4"
   },
   "types": "./dist/client/index.d.ts",
-  "module": "./dist/client/index.js"
+  "module": "./dist/client/index.js",
+  "dependencies": {
+    "convex-helpers": "^0.1.118"
+  }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,6 +6,7 @@ import type {
   HttpRouter,
 } from "convex/server";
 import { v } from "convex/values";
+import type { ComponentApi } from "../component/_generated/component.js";
 import type {
   Customer,
   Entitlement,
@@ -20,72 +21,10 @@ import type {
   VirtualCurrencyTransaction,
 } from "../component/types.js";
 
-// Convex generates component types with "internal" visibility in consumer apps
-// regardless of how they're defined in the component. Define the expected API
-// shape directly to avoid visibility mismatches.
-type AnyVisibility = "public" | "internal";
-
 type GracePeriodReturn = {
   inGracePeriod: boolean;
   gracePeriodExpiresAt?: number;
   billingIssueDetectedAt?: number;
-};
-
-type ClientComponentApi = {
-  entitlements: {
-    check: FunctionReference<"query", AnyVisibility, { appUserId: string; entitlementId: string }, boolean>;
-    getActive: FunctionReference<"query", AnyVisibility, { appUserId: string }, Entitlement[]>;
-    list: FunctionReference<"query", AnyVisibility, { appUserId: string }, Entitlement[]>;
-  };
-  subscriptions: {
-    getActive: FunctionReference<"query", AnyVisibility, { appUserId: string }, Subscription[]>;
-    getConsumables: FunctionReference<"query", AnyVisibility, { appUserId: string }, Subscription[]>;
-    getByUser: FunctionReference<"query", AnyVisibility, { appUserId: string }, Subscription[]>;
-    isInGracePeriod: FunctionReference<"query", AnyVisibility, { originalTransactionId: string }, GracePeriodReturn>;
-    getInGracePeriod: FunctionReference<"query", AnyVisibility, { appUserId: string }, Subscription[]>;
-    backfillKind: FunctionReference<"mutation", AnyVisibility, { cursor?: string; pageSize?: number }, { scanned: number; written: number; nextCursor: string | null }>;
-  };
-  customers: {
-    get: FunctionReference<"query", AnyVisibility, { appUserId: string }, Customer | null>;
-    purge: FunctionReference<"mutation", AnyVisibility, { appUserId: string; onCustomerDeleted?: string }, DeleteCustomerResult>;
-  };
-  experiments: {
-    get: FunctionReference<"query", AnyVisibility, { appUserId: string; experimentId: string }, Experiment | null>;
-    list: FunctionReference<"query", AnyVisibility, { appUserId: string }, Experiment[]>;
-  };
-  transfers: {
-    getByEventId: FunctionReference<"query", AnyVisibility, { eventId: string }, Transfer | null>;
-    list: FunctionReference<"query", AnyVisibility, { limit?: number }, Transfer[]>;
-  };
-  invoices: {
-    get: FunctionReference<"query", AnyVisibility, { invoiceId: string }, Invoice | null>;
-    listByUser: FunctionReference<"query", AnyVisibility, { appUserId: string }, Invoice[]>;
-  };
-  virtualCurrency: {
-    getBalance: FunctionReference<"query", AnyVisibility, { appUserId: string; currencyCode: string }, VirtualCurrencyBalance | null>;
-    listBalances: FunctionReference<"query", AnyVisibility, { appUserId: string }, VirtualCurrencyBalance[]>;
-    listTransactions: FunctionReference<"query", AnyVisibility, { appUserId: string; currencyCode?: string }, VirtualCurrencyTransaction[]>;
-  };
-  webhooks: {
-    process: FunctionReference<"mutation", AnyVisibility, { event: { id: string; type: string; app_id?: string; app_user_id?: string; environment: Environment; store?: Store }; payload: Record<string, unknown>; hooks?: { onEntitlementActivated?: string; onEntitlementDeactivated?: string } }, { processed: boolean; eventId: string }>;
-    recordFailure: FunctionReference<"mutation", AnyVisibility, { event: { id: string; type: string; app_id?: string; app_user_id?: string; environment: Environment; store?: Store }; payload: Record<string, unknown>; error: string }, null>;
-  };
-  sync: {
-    ingest: FunctionReference<"mutation", AnyVisibility, { appUserId: string; subscriber: RevenueCatSubscriberInput; hooks?: { onEntitlementActivated?: string; onEntitlementDeactivated?: string } }, SyncResult>;
-  };
-};
-
-type RevenueCatSubscriberInput = {
-  entitlements?: Record<string, unknown>;
-  subscriptions?: Record<string, unknown>;
-  non_subscriptions?: Record<string, unknown>;
-  subscriber_attributes?: Record<string, unknown>;
-  first_seen?: string;
-  last_seen?: string;
-  original_app_user_id?: string;
-  /** Native subscription-manager deep link from RC's REST. iOS routes to App
-   * Store settings, Android to Play Store, web to the Stripe portal. */
-  management_url?: string;
 };
 
 export type {
@@ -480,7 +419,7 @@ function transformPayload(obj: unknown): unknown {
 
 export class RevenueCat {
   constructor(
-    public component: ClientComponentApi,
+    public component: ComponentApi,
     public options: RevenueCatOptions = {},
   ) {
     // `undefined` is allowed here for query-only consumers. `httpHandler()`

--- a/src/component/audit-fixes.test.ts
+++ b/src/component/audit-fixes.test.ts
@@ -32,7 +32,7 @@ async function postEvent(
   t: ReturnType<typeof initConvexTest>,
   payload: Record<string, unknown>,
 ) {
-  return t.mutation(api.webhooks.process, {
+  return t.mutation(internal.webhooks.process, {
     event: {
       id: payload.id as string,
       type: payload.type as string,
@@ -1216,7 +1216,7 @@ describe("audit fixes", () => {
       // Direct invocation (unreachable from the wire) still throws.
       const t = initConvexTest();
       await expect(
-        t.mutation(api.webhooks.process, {
+        t.mutation(internal.webhooks.process, {
           event: {
             id: "   ",
             type: "INITIAL_PURCHASE",
@@ -1240,11 +1240,11 @@ describe("audit fixes", () => {
         });
       });
 
-      const first = await t.mutation(api.transfers.backfillTransferParticipants, {});
+      const first = await t.mutation(internal.transfers.backfillTransferParticipants, {});
       expect(first.written).toBe(2);
       expect(first.nextCursor).toBeNull();
 
-      const second = await t.mutation(api.transfers.backfillTransferParticipants, {});
+      const second = await t.mutation(internal.transfers.backfillTransferParticipants, {});
       expect(second.written).toBe(0);
 
       const participants = await t.run(async (ctx) => {
@@ -1297,7 +1297,7 @@ describe("audit fixes", () => {
         }
       });
 
-      const first = await t.mutation(api.subscriptions.backfillKind, {});
+      const first = await t.mutation(internal.subscriptions.backfillKind, {});
       expect(first.written).toBe(1);
       expect(first.nextCursor).toBeNull();
 
@@ -1308,7 +1308,7 @@ describe("audit fixes", () => {
       expect(recurring?.kind).toBeUndefined();
 
       // Idempotent: a second run finds nothing to do.
-      const second = await t.mutation(api.subscriptions.backfillKind, {});
+      const second = await t.mutation(internal.subscriptions.backfillKind, {});
       expect(second.written).toBe(0);
     });
 
@@ -1340,7 +1340,7 @@ describe("audit fixes", () => {
       const beforeActive = await t.query(api.subscriptions.getActive, { appUserId: subject });
       expect(beforeActive.length).toBe(1);
 
-      await t.mutation(api.subscriptions.backfillKind, {});
+      await t.mutation(internal.subscriptions.backfillKind, {});
 
       const afterActive = await t.query(api.subscriptions.getActive, { appUserId: subject });
       expect(afterActive.length).toBe(0);

--- a/src/component/handlers.test.ts
+++ b/src/component/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { api } from "./_generated/api.js";
+import { api, internal } from "./_generated/api.js";
 import { initConvexTest } from "./setup.test.js";
 
 function createEventPayload(
@@ -63,7 +63,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium", "pro"],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -96,7 +96,7 @@ describe("handlers", () => {
         app_user_id: "user_initial_2",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -128,7 +128,7 @@ describe("handlers", () => {
         is_family_share: undefined,
         ownership_type: "FAMILY_SHARED",
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -158,7 +158,7 @@ describe("handlers", () => {
         }),
         ownership_type: "FAMILY_SHARED",
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -185,7 +185,7 @@ describe("handlers", () => {
         product_id: "premium_yearly",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -218,7 +218,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -238,7 +238,7 @@ describe("handlers", () => {
         cancel_reason: "UNSUBSCRIBE",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -268,7 +268,7 @@ describe("handlers", () => {
         app_user_id: "user_cancel_refund",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -296,7 +296,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
         cancel_reason: "CUSTOMER_SUPPORT",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -332,7 +332,7 @@ describe("handlers", () => {
         type: "INITIAL_PURCHASE",
         app_user_id: "user_cancel_exp",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -352,7 +352,7 @@ describe("handlers", () => {
         }),
         experiments: experimentsArr,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -382,7 +382,7 @@ describe("handlers", () => {
         app_user_id: "user_refund_ts",
         original_transaction_id: "txn_refund_ts",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -403,7 +403,7 @@ describe("handlers", () => {
         }),
         event_timestamp_ms: refundTime,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -429,7 +429,7 @@ describe("handlers", () => {
         app_user_id: "user_nrefund",
         original_transaction_id: "txn_nrefund",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -447,7 +447,7 @@ describe("handlers", () => {
         original_transaction_id: "txn_nrefund",
         cancel_reason: "UNSUBSCRIBE",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -474,7 +474,7 @@ describe("handlers", () => {
         app_user_id: "user_cancel_negprice",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -497,7 +497,7 @@ describe("handlers", () => {
         }),
         price: -9.99,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -526,7 +526,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -546,7 +546,7 @@ describe("handlers", () => {
         }),
         entitlement_ids: undefined,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -578,7 +578,7 @@ describe("handlers", () => {
         expiration_at_ms: Date.now() + 1000,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -604,7 +604,7 @@ describe("handlers", () => {
         expiration_reason: "SUBSCRIPTION_EXPIRED",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -644,7 +644,7 @@ describe("handlers", () => {
       });
 
       for (const p of [premiumPayload, proPayload]) {
-        await t.mutation(api.webhooks.process, {
+        await t.mutation(internal.webhooks.process, {
           event: { id: p.id, type: p.type, app_id: p.app_id, app_user_id: p.app_user_id, environment: p.environment, store: p.store },
           payload: p,
         });
@@ -661,7 +661,7 @@ describe("handlers", () => {
         entitlement_ids: undefined,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: { id: expirePayload.id, type: expirePayload.type, app_id: expirePayload.app_id, app_user_id: expirePayload.app_user_id, environment: expirePayload.environment, store: expirePayload.store },
         payload: expirePayload,
       });
@@ -685,7 +685,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -705,7 +705,7 @@ describe("handlers", () => {
         auto_resume_at_ms: futureResume,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: pausePayload.id,
           type: pausePayload.type,
@@ -739,7 +739,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -769,7 +769,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: transferPayload.id,
           type: transferPayload.type,
@@ -808,7 +808,7 @@ describe("handlers", () => {
         expiration_at_ms: newerExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: sourcePayload.id,
           type: sourcePayload.type,
@@ -828,7 +828,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: destPayload.id,
           type: destPayload.type,
@@ -852,7 +852,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: transferPayload.id,
           type: transferPayload.type,
@@ -895,7 +895,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -917,7 +917,7 @@ describe("handlers", () => {
         grace_period_expiration_at_ms: gracePeriodExpiration,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -968,7 +968,7 @@ describe("handlers", () => {
         }),
         grace_period_expiration_at_ms: Date.now() + 7 * 24 * 60 * 60 * 1000,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -995,7 +995,7 @@ describe("handlers", () => {
         app_user_id: "user_billing_ceiling",
         expiration_at_ms: Date.now() + 1000, // soon-to-expire
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1015,7 +1015,7 @@ describe("handlers", () => {
         }),
         grace_period_expiration_at_ms: gracePeriodEnd,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -1055,7 +1055,7 @@ describe("handlers", () => {
         expiration_at_ms: initialExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1074,7 +1074,7 @@ describe("handlers", () => {
         expiration_at_ms: renewedExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: renewPayload.id,
           type: renewPayload.type,
@@ -1114,7 +1114,7 @@ describe("handlers", () => {
         expiration_at_ms: renewedExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: { id: renewPayload.id, type: renewPayload.type, app_id: renewPayload.app_id, app_user_id: renewPayload.app_user_id, environment: renewPayload.environment, store: renewPayload.store },
         payload: renewPayload,
       });
@@ -1140,7 +1140,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1164,7 +1164,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -1193,7 +1193,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: uncancelPayload.id,
           type: uncancelPayload.type,
@@ -1232,7 +1232,7 @@ describe("handlers", () => {
         expiration_at_ms: initialExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1251,7 +1251,7 @@ describe("handlers", () => {
         expiration_at_ms: extendedExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: extendPayload.id,
           type: extendPayload.type,
@@ -1291,7 +1291,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1316,7 +1316,7 @@ describe("handlers", () => {
         new_product_id: "yearly_premium",
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: changePayload.id,
           type: changePayload.type,
@@ -1357,7 +1357,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1403,7 +1403,7 @@ describe("handlers", () => {
         expiration_at_ms: tempExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1443,7 +1443,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1463,7 +1463,7 @@ describe("handlers", () => {
         expiration_reason: "CUSTOMER_SUPPORT",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -1488,7 +1488,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundReversedPayload.id,
           type: refundReversedPayload.type,
@@ -1519,7 +1519,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1546,7 +1546,7 @@ describe("handlers", () => {
         store: "RC_BILLING" as const,
       };
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1577,7 +1577,7 @@ describe("handlers", () => {
         source: "in_app_purchase",
       };
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1609,7 +1609,7 @@ describe("handlers", () => {
         source: "in_app_purchase",
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: { id: payload.id, type: payload.type, app_user_id: payload.app_user_id, environment: payload.environment, store: payload.store },
         payload,
       });
@@ -1652,7 +1652,7 @@ describe("handlers", () => {
         experiment_enrolled_at_ms: Date.now(),
       };
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1681,7 +1681,7 @@ describe("handlers", () => {
         experiment_enrolled_at_ms: enrolledAt,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1721,7 +1721,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload1.id,
           type: payload1.type,
@@ -1752,7 +1752,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload2.id,
           type: payload2.type,
@@ -1793,7 +1793,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1836,7 +1836,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload1.id,
           type: payload1.type,
@@ -1864,7 +1864,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload2.id,
           type: payload2.type,
@@ -1903,7 +1903,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1943,7 +1943,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1976,7 +1976,7 @@ describe("handlers", () => {
         app_user_id: "user_alias_test",
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1997,7 +1997,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2031,7 +2031,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2062,7 +2062,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2112,7 +2112,7 @@ describe("handlers", () => {
         original_app_user_id: realUserId,
         expiration_at_ms: now + 10 * 24 * 60 * 60 * 1000, // +10 days
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: realPurchase.id,
           type: realPurchase.type,
@@ -2131,7 +2131,7 @@ describe("handlers", () => {
         original_app_user_id: anonymousId,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000, // +30 days (newer)
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: anonPurchase.id,
           type: anonPurchase.type,
@@ -2150,7 +2150,7 @@ describe("handlers", () => {
         original_app_user_id: anonymousId,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -2179,7 +2179,7 @@ describe("handlers", () => {
         aliases: [anonymousId],
         environment: "SANDBOX" as const,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2250,7 +2250,7 @@ describe("handlers", () => {
         aliases: [anonymousId],
         environment: "SANDBOX" as const,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2279,7 +2279,7 @@ describe("handlers", () => {
         app_user_id: "user_refund_1",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2303,7 +2303,7 @@ describe("handlers", () => {
         expiration_at_ms: Date.now() - 1000,
         expiration_reason: "CUSTOMER_SUPPORT",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -2331,7 +2331,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2352,7 +2352,7 @@ describe("handlers", () => {
         }),
         entitlement_ids: undefined,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -2416,7 +2416,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 60 * 86400000,
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,

--- a/src/component/hooks.test.ts
+++ b/src/component/hooks.test.ts
@@ -86,7 +86,7 @@ describe("lifecycle hooks", () => {
         entitlement_ids: ["premium", "pro"],
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -120,7 +120,7 @@ describe("lifecycle hooks", () => {
       const userId = "user_hook_already_active";
 
       // First purchase activates.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_hook_a1",
           type: "INITIAL_PURCHASE",
@@ -133,7 +133,7 @@ describe("lifecycle hooks", () => {
 
       // Second event with the same entitlement but NEW transaction id shouldn't
       // double-fire the hook (state is already active).
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_hook_a2",
           type: "RENEWAL",
@@ -165,7 +165,7 @@ describe("lifecycle hooks", () => {
       });
 
       // First delivery activates + fires hook.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -179,7 +179,7 @@ describe("lifecycle hooks", () => {
 
       // RC retries, same event.id. The outer mutation short-circuits via
       // the webhookEvents dedup check. No snapshot or hook fires on retry.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -202,7 +202,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_hook_expire";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_hook_e1",
           type: "INITIAL_PURCHASE",
@@ -220,7 +220,7 @@ describe("lifecycle hooks", () => {
         expiration_at_ms: Date.now() - 1000,
         original_transaction_id: "txn_original_evt_hook_e1",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -245,7 +245,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_hook_refund";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_hook_r1",
           type: "INITIAL_PURCHASE",
@@ -265,7 +265,7 @@ describe("lifecycle hooks", () => {
         }),
         cancel_reason: "CUSTOMER_SUPPORT",
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -289,7 +289,7 @@ describe("lifecycle hooks", () => {
       const source = "user_transfer_src";
       const dest = "user_transfer_dst";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_t_seed",
           type: "INITIAL_PURCHASE",
@@ -300,7 +300,7 @@ describe("lifecycle hooks", () => {
         payload: createPurchasePayload({ id: "evt_t_seed", app_user_id: source }),
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_transfer",
           type: "TRANSFER",
@@ -439,7 +439,7 @@ describe("lifecycle hooks", () => {
       const t = initConvexTest();
       const handle = await handleFor(t, internal.lib.noop);
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_purge_seed",
           type: "INITIAL_PURCHASE",
@@ -489,7 +489,7 @@ describe("lifecycle hooks", () => {
         purchased_at_ms: now,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000,
       };
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -567,7 +567,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_deact_args";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_deact_args_1",
           type: "INITIAL_PURCHASE",
@@ -585,7 +585,7 @@ describe("lifecycle hooks", () => {
         expiration_at_ms: Date.now() - 1000,
         original_transaction_id: "txn_original_evt_deact_args_1",
       });
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -618,7 +618,7 @@ describe("lifecycle hooks", () => {
       // No handler matches a UNKNOWN event type, so the dispatch table
       // short-circuits to status="ignored" and never reads entitlements or
       // fires hooks.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_unknown_rollback",
           type: "FUTURE_UNKNOWN_EVENT",
@@ -643,7 +643,7 @@ describe("lifecycle hooks", () => {
       const t = initConvexTest();
       const handle = await handleFor(t, internal.lib.noop);
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_test",
           type: "TEST",
@@ -674,7 +674,7 @@ describe("lifecycle hooks", () => {
       const real = "user_real";
 
       // Seed an anonymous user with an active entitlement.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_alias_seed",
           type: "INITIAL_PURCHASE",
@@ -692,7 +692,7 @@ describe("lifecycle hooks", () => {
       // aliases array carries both IDs. AffectedUserIds must pick up both so
       // the migration's deactivation from anon and activation on real are
       // detected.
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_alias_migrate",
           type: "SUBSCRIBER_ALIAS",
@@ -733,7 +733,7 @@ describe("lifecycle hooks", () => {
         app_user_id: "user_no_hooks",
       });
 
-      const result = await t.mutation(api.webhooks.process, {
+      const result = await t.mutation(internal.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,

--- a/src/component/invoices.test.ts
+++ b/src/component/invoices.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { initConvexTest } from "./setup.test.js";
-import { api } from "./_generated/api.js";
+import { api, internal } from "./_generated/api.js";
 
 describe("invoices", () => {
   describe("get", () => {
@@ -16,7 +16,7 @@ describe("invoices", () => {
       const t = initConvexTest();
 
       // INVOICE_ISSUANCE uses event.id as the invoice identifier (no separate invoice_id field)
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_invoice_1",
           type: "INVOICE_ISSUANCE",
@@ -65,7 +65,7 @@ describe("invoices", () => {
       const userId = "user_multi_invoice";
 
       for (let i = 1; i <= 3; i++) {
-        await t.mutation(api.webhooks.process, {
+        await t.mutation(internal.webhooks.process, {
           event: {
             id: `evt_inv_${i}`,
             type: "INVOICE_ISSUANCE",

--- a/src/component/parity-fixes.test.ts
+++ b/src/component/parity-fixes.test.ts
@@ -61,7 +61,7 @@ async function dispatch(
   t: ReturnType<typeof initConvexTest>,
   payload: ReturnType<typeof basePayload>,
 ) {
-  await t.mutation(api.webhooks.process, {
+  await t.mutation(internal.webhooks.process, {
     event: {
       id: payload.id,
       type: payload.type,

--- a/src/component/subscriptions.ts
+++ b/src/component/subscriptions.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { paginator } from "convex-helpers/server/pagination";
+import { internalMutation, query } from "./_generated/server.js";
 import schema from "./schema.js";
 
 const subscriptionDoc = schema.tables.subscriptions.validator.extend({
@@ -73,7 +74,7 @@ export const getConsumables = query({
  * NON_RENEWING_PURCHASE event predates retention can't be backfilled this
  * way and stay `kind: undefined` (so `getActiveSubscriptions` will keep
  * returning them). Operators with older data should patch directly. */
-export const backfillKind = mutation({
+export const backfillKind = internalMutation({
   args: {
     cursor: v.optional(v.string()),
     pageSize: v.optional(v.number()),
@@ -85,7 +86,7 @@ export const backfillKind = mutation({
   }),
   handler: async (ctx, args) => {
     const pageSize = Math.min(args.pageSize ?? 256, 1000);
-    const page = await ctx.db
+    const page = await paginator(ctx.db, schema)
       .query("webhookEvents")
       .withIndex("by_type", (q) => q.eq("eventType", "NON_RENEWING_PURCHASE"))
       .paginate({ cursor: args.cursor ?? null, numItems: pageSize });

--- a/src/component/transfers.test.ts
+++ b/src/component/transfers.test.ts
@@ -15,7 +15,7 @@ describe("transfers", () => {
     test("returns transfer after TRANSFER event", async () => {
       const t = initConvexTest();
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_transfer_1",
           type: "TRANSFER",
@@ -54,7 +54,7 @@ describe("transfers", () => {
       const t = initConvexTest();
       const now = Date.now();
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_transfer_old",
           type: "TRANSFER",
@@ -70,7 +70,7 @@ describe("transfers", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_transfer_new",
           type: "TRANSFER",
@@ -128,7 +128,7 @@ describe("transfers", () => {
       expect(sourceSubs).toHaveLength(1);
 
       // Process TRANSFER event
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_transfer_sub",
           type: "TRANSFER",

--- a/src/component/transfers.ts
+++ b/src/component/transfers.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server.js";
+import { paginator } from "convex-helpers/server/pagination";
+import { internalMutation, query } from "./_generated/server.js";
 import schema from "./schema.js";
 
 const transferDoc = schema.tables.transfers.validator.extend({
@@ -36,7 +37,7 @@ export const list = query({
 
 /** Backfill `transferParticipants` for pre-0.3.0 `transfers` rows. Run once
  * after upgrading. Idempotent. Loop until `nextCursor` is null. */
-export const backfillTransferParticipants = mutation({
+export const backfillTransferParticipants = internalMutation({
   args: {
     cursor: v.optional(v.string()),
     pageSize: v.optional(v.number()),
@@ -48,7 +49,7 @@ export const backfillTransferParticipants = mutation({
   }),
   handler: async (ctx, args) => {
     const pageSize = Math.min(args.pageSize ?? 256, 1000);
-    const page = await ctx.db
+    const page = await paginator(ctx.db, schema)
       .query("transfers")
       .paginate({ cursor: args.cursor ?? null, numItems: pageSize });
     let written = 0;

--- a/src/component/virtualCurrency.test.ts
+++ b/src/component/virtualCurrency.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { initConvexTest } from "./setup.test.js";
-import { api } from "./_generated/api.js";
+import { api, internal } from "./_generated/api.js";
 
 describe("virtualCurrency", () => {
   describe("getBalance", () => {
@@ -16,7 +16,7 @@ describe("virtualCurrency", () => {
     test("returns balance after VIRTUAL_CURRENCY_TRANSACTION event", async () => {
       const t = initConvexTest();
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_vc_1",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -59,7 +59,7 @@ describe("virtualCurrency", () => {
       const userId = "user_vc_accumulate";
 
       // First transaction: +100
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_vc_add",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -83,7 +83,7 @@ describe("virtualCurrency", () => {
       });
 
       // Second transaction: -30 (refund)
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_vc_sub",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -120,7 +120,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_multi_currency";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_vc_multi",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -157,7 +157,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_tx_list";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_tx_1",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -176,7 +176,7 @@ describe("virtualCurrency", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_tx_2",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -206,7 +206,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_tx_filter";
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_tx_coins",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -224,7 +224,7 @@ describe("virtualCurrency", () => {
         },
       });
 
-      await t.mutation(api.webhooks.process, {
+      await t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_tx_gems",
           type: "VIRTUAL_CURRENCY_TRANSACTION",

--- a/src/component/webhooks.test.ts
+++ b/src/component/webhooks.test.ts
@@ -41,7 +41,7 @@ describe("webhook validation", () => {
     const payload = createEventPayload({ id: "   " });
 
     await expect(
-      t.mutation(api.webhooks.process, {
+      t.mutation(internal.webhooks.process, {
         event: {
           id: "   ",
           type: payload.type,
@@ -58,7 +58,7 @@ describe("webhook validation", () => {
     const payload = createEventPayload({ id: "evt_valid_id" });
 
     await expect(
-      t.mutation(api.webhooks.process, {
+      t.mutation(internal.webhooks.process, {
         event: {
           id: "evt_valid_id",
           type: "   ",
@@ -101,7 +101,7 @@ describe("future-proofing", () => {
       another_future_field: 42,
       nested_future_object: { a: 1, b: [true, null] },
     };
-    await t.mutation(api.webhooks.process, {
+    await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -126,7 +126,7 @@ describe("webhooks", () => {
 
     const payload = createEventPayload({ id: "evt_123" });
 
-    const result = await t.mutation(api.webhooks.process, {
+    const result = await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -147,7 +147,7 @@ describe("webhooks", () => {
 
     const payload = createEventPayload({ id: "evt_456", type: "RENEWAL" });
 
-    const first = await t.mutation(api.webhooks.process, {
+    const first = await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -158,7 +158,7 @@ describe("webhooks", () => {
 
     expect(first.processed).toBe(true);
 
-    const second = await t.mutation(api.webhooks.process, {
+    const second = await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -181,7 +181,7 @@ describe("webhooks", () => {
       environment: "SANDBOX" as const,
     };
 
-    const result = await t.mutation(api.webhooks.process, {
+    const result = await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -194,7 +194,7 @@ describe("webhooks", () => {
     expect(result.processed).toBe(false);
     expect(result.eventId).toBe("evt_unknown_1");
 
-    const secondResult = await t.mutation(api.webhooks.process, {
+    const secondResult = await t.mutation(internal.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,

--- a/src/component/webhooks.ts
+++ b/src/component/webhooks.ts
@@ -1,5 +1,5 @@
 import { v, ConvexError } from "convex/values";
-import { internalMutation, mutation } from "./_generated/server.js";
+import { internalMutation } from "./_generated/server.js";
 import { internal } from "./_generated/api.js";
 import { environmentValidator, storeValidator } from "./schema.js";
 import {
@@ -80,7 +80,7 @@ export const checkRateLimit = internalMutation({
   },
 });
 
-export const process = mutation({
+export const process = internalMutation({
   args: {
     event: v.object({
       id: v.string(),


### PR DESCRIPTION
Bring the component in line with Convex's component-authoring guidelines.

`process`, `backfillKind`, and `backfillTransferParticipants` are only invoked by other functions (the webhook HTTP handler, or operators), never by a client, so they become `internalMutation` to keep the component's public surface small. The two backfills now paginate with `convex-helpers`' `paginator`, since the built-in `.paginate()` does not work across the component boundary. The client constructor takes the component's generated `ComponentApi` type instead of a hand-written mirror.

- `webhooks.ts`: `process` -> `internalMutation`
- `subscriptions.ts`, `transfers.ts`: backfills -> `internalMutation`, paginate via `paginator(ctx.db, schema)`
- `package.json`: add `convex-helpers` dependency
- component tests: reference these functions via `internal.*`
- `client/index.ts`: ctor param typed as the generated `ComponentApi`, drop the bespoke `ClientComponentApi` and `AnyVisibility` types