### PR TITLE
test(client): add ComponentApi constructor contract check

### DIFF
--- a/src/client/component-contract.test.ts
+++ b/src/client/component-contract.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { RevenueCat } from "./index.js";
+import type { ComponentApi } from "../component/_generated/component.js";
+
+// A deployed consumer's `components.revenuecat` resolves to
+// `ComponentApi<"revenuecat">`. It must satisfy the `RevenueCat` constructor so
+// the documented `new RevenueCat(components.revenuecat, ...)` call typechecks.
+// The example app only exercises this via its committed precise generated
+// types; this locks the contract directly, so drift between the generated
+// component API and the client constructor fails CI. (The pre-`convex dev`
+// `AnyComponents` stub is a separate, expected Convex limitation.)
+type Expect<T extends true> = T;
+type ComponentApiSatisfiesCtor = Expect<
+  ComponentApi<"revenuecat"> extends ConstructorParameters<typeof RevenueCat>[0]
+    ? true
+    : false
+>;
+
+test("generated ComponentApi satisfies the RevenueCat constructor", () => {
+  const enforced: ComponentApiSatisfiesCtor = true;
+  expect(enforced).toBe(true);
+});


### PR DESCRIPTION
Lock the consumer contract directly so CI catches drift between the component's generated API and the client constructor.

A deployed consumer's `components.revenuecat` resolves to `ComponentApi<"revenuecat">`, which must satisfy the `RevenueCat` constructor for the documented `new RevenueCat(components.revenuecat, ...)` call to typecheck. The example app exercises this only through its committed precise generated types, so a ctor/`ComponentApi` mismatch could slip through. This adds a compile-time assertion that fails `tsc` and `vitest --typecheck` if the contract breaks.

- `src/client/component-contract.test.ts`: type-level assertion that `ComponentApi<"revenuecat">` extends the `RevenueCat` constructor parameter