### PR TITLE
fix(component): resolve Convex + RevenueCat skills-audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,22 +482,26 @@ Two internal cleanup mutations keep the bookkeeping tables bounded. They are NOT
 
 Both delete in batches and self-reschedule when a backlog exceeds the per-run cap, so one cron tick drains any backlog.
 
+Wrap them in an app-side `internalMutation` and schedule that. A cron can't schedule `components.revenuecat.cleanup.*` directly: crons serialize the target by name, and a component reference has no same-deployment name, so the push fails.
+
 ```typescript
 import { cronJobs } from "convex/server";
-import { components } from "./_generated/api";
+import { internalMutation } from "./_generated/server";
+import { components, internal } from "./_generated/api";
+
+export const pruneRevenueCat = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.runMutation(components.revenuecat.cleanup.rateLimits, {});
+    await ctx.runMutation(components.revenuecat.cleanup.webhookEvents, {});
+  },
+});
 
 const crons = cronJobs();
-
 crons.interval(
-  "revenuecat: prune rate limits",
+  "prune revenuecat bookkeeping",
   { hours: 1 },
-  components.revenuecat.cleanup.rateLimits,
-  {},
-);
-crons.interval(
-  "revenuecat: prune webhook events",
-  { hours: 24 },
-  components.revenuecat.cleanup.webhookEvents,
+  internal.crons.pruneRevenueCat,
   {},
 );
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,37 @@ console.log(attrs?.$email?.value); // "user@example.com"
 - `event.id` is capped at 128 bytes. Webhook bodies are capped at 1MB. Both reject at the HTTP boundary before any database touch.
 - `event.event_timestamp_ms` is clamped to `now + 5min` on insert so a clock-skewed or malicious timestamp can't lock `customers.firstSeenAt` / `lastSeenAt` at a far-future value.
 
+## Maintenance
+
+Two internal cleanup mutations keep the bookkeeping tables bounded. They are NOT scheduled automatically: register them in your app's `crons.ts`, or `rateLimits` and the webhook audit log grow without limit.
+
+- `cleanup.rateLimits` drops rate-limit rows older than the 60s window.
+- `cleanup.webhookEvents` drops audit rows past the 30-day retention.
+
+Both delete in batches and self-reschedule when a backlog exceeds the per-run cap, so one cron tick drains any backlog.
+
+```typescript
+import { cronJobs } from "convex/server";
+import { components } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.interval(
+  "revenuecat: prune rate limits",
+  { hours: 1 },
+  components.revenuecat.cleanup.rateLimits,
+  {},
+);
+crons.interval(
+  "revenuecat: prune webhook events",
+  { hours: 24 },
+  components.revenuecat.cleanup.webhookEvents,
+  {},
+);
+
+export default crons;
+```
+
 ## Upgrading from 0.2.1
 
 If your deployment shipped 0.2.1 or earlier, run two one-shot migrations after upgrading. Both are idempotent and paginated. Loop until `nextCursor` is null.
@@ -506,7 +537,7 @@ export const backfillRevenueCat = internalAction({
 
 ## GDPR / data deletion
 
-`deleteCustomer(ctx, { appUserId })` purges all component-local rows for a user: customer, subscriptions, entitlements, experiments, invoices, virtual currency balances/transactions, webhook events, and transfers. Call from a mutation or action.
+`deleteCustomer(ctx, { appUserId })` purges all component-local rows for a user: customer, subscriptions, entitlements, experiments, invoices, virtual currency balances/transactions, webhook events (including the `TRANSFER` audit rows, which carry no `app_user_id` and are matched through the user's transfer records), and transfers. Audit rows recorded under a prior alias ID age out via the 30-day retention. Call from a mutation or action.
 
 To also purge RevenueCat-side, call `DELETE /v1/subscribers/{app_user_id}` from a Convex action with a secret API key. RC confirms the delete endpoint is sufficient for GDPR erasure on their side.
 

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -8,12 +8,14 @@
  * @module
  */
 
+import type * as crons from "../crons.js";
 import type * as http from "../http.js";
 import type * as subscriptions from "../subscriptions.js";
 
 import type { ApiFromModules, FilterApi, FunctionReference } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
   http: typeof http;
   subscriptions: typeof subscriptions;
 }>;

--- a/example/convex/crons.ts
+++ b/example/convex/crons.ts
@@ -1,0 +1,23 @@
+import { cronJobs } from "convex/server";
+import { components } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Prune expired rate-limit rows (60s window) hourly. The mutation deletes in
+// batches and self-reschedules when a backlog exceeds the per-run cap.
+crons.interval(
+  "revenuecat: prune rate limits",
+  { hours: 1 },
+  components.revenuecat.cleanup.rateLimits,
+  {},
+);
+
+// Drop webhook audit events past the 30-day retention, daily.
+crons.interval(
+  "revenuecat: prune webhook events",
+  { hours: 24 },
+  components.revenuecat.cleanup.webhookEvents,
+  {},
+);
+
+export default crons;

--- a/example/convex/crons.ts
+++ b/example/convex/crons.ts
@@ -1,22 +1,28 @@
 import { cronJobs } from "convex/server";
-import { components } from "./_generated/api";
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+import { components, internal } from "./_generated/api";
+
+// Component functions are reached across the component boundary via
+// ctx.runMutation, so wrap them in an app-side internal mutation and schedule
+// that. Scheduling `components.revenuecat.cleanup.*` directly from a cron fails
+// the push: crons serialize the target by name, and a component reference has
+// no same-deployment name.
+export const pruneRevenueCat = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    await ctx.runMutation(components.revenuecat.cleanup.rateLimits, {});
+    await ctx.runMutation(components.revenuecat.cleanup.webhookEvents, {});
+    return null;
+  },
+});
 
 const crons = cronJobs();
-
-// Prune expired rate-limit rows (60s window) hourly. The mutation deletes in
-// batches and self-reschedules when a backlog exceeds the per-run cap.
 crons.interval(
-  "revenuecat: prune rate limits",
+  "prune revenuecat bookkeeping",
   { hours: 1 },
-  components.revenuecat.cleanup.rateLimits,
-  {},
-);
-
-// Drop webhook audit events past the 30-day retention, daily.
-crons.interval(
-  "revenuecat: prune webhook events",
-  { hours: 24 },
-  components.revenuecat.cleanup.webhookEvents,
+  internal.crons.pruneRevenueCat,
   {},
 );
 

--- a/src/client/component-contract.test.ts
+++ b/src/client/component-contract.test.ts
@@ -36,6 +36,9 @@ type AllInternal = AllTrue<
     IsInternal<Api["transfers"]["backfillTransferParticipants"]>,
     IsInternal<Api["invoices"]["get"]>,
     IsInternal<Api["webhooks"]["process"]>,
+    // cleanup.* must stay reachable: consumers schedule it from crons.
+    IsInternal<Api["cleanup"]["rateLimits"]>,
+    IsInternal<Api["cleanup"]["webhookEvents"]>,
   ]
 >;
 

--- a/src/client/component-contract.test.ts
+++ b/src/client/component-contract.test.ts
@@ -1,22 +1,46 @@
 import { expect, test } from "vitest";
 import { RevenueCat } from "./index.js";
+import type { FunctionReference } from "convex/server";
 import type { ComponentApi } from "../component/_generated/component.js";
 
-// A deployed consumer's `components.revenuecat` resolves to
-// `ComponentApi<"revenuecat">`. It must satisfy the `RevenueCat` constructor so
-// the documented `new RevenueCat(components.revenuecat, ...)` call typechecks.
-// The example app only exercises this via its committed precise generated
-// types; this locks the contract directly, so drift between the generated
-// component API and the client constructor fails CI. (The pre-`convex dev`
-// `AnyComponents` stub is a separate, expected Convex limitation.)
 type Expect<T extends true> = T;
-type ComponentApiSatisfiesCtor = Expect<
+
+// 1. A deployed consumer's `components.revenuecat` resolves to
+//    `ComponentApi<"revenuecat">`, which must satisfy the `RevenueCat`
+//    constructor so the documented `new RevenueCat(components.revenuecat, ...)`
+//    call typechecks.
+type CtorAcceptsComponentApi = Expect<
   ComponentApi<"revenuecat"> extends ConstructorParameters<typeof RevenueCat>[0]
     ? true
     : false
 >;
 
-test("generated ComponentApi satisfies the RevenueCat constructor", () => {
-  const enforced: ComponentApiSatisfiesCtor = true;
-  expect(enforced).toBe(true);
+// 2. Convex codegen stamps every component function "internal". This file is
+//    hand-maintained, so lock that invariant: a hand-edit re-introducing
+//    "public" (which `npx convex dev` would revert, a silent breaking type
+//    change for consumers) fails this typecheck.
+type IsInternal<T> = T extends FunctionReference<any, "internal", any, any, any>
+  ? true
+  : false;
+type Api = ComponentApi<"revenuecat">;
+type AllTrue<_T extends readonly true[]> = true;
+type AllInternal = AllTrue<
+  [
+    IsInternal<Api["customers"]["get"]>,
+    IsInternal<Api["customers"]["purge"]>,
+    IsInternal<Api["entitlements"]["list"]>,
+    IsInternal<Api["sync"]["ingest"]>,
+    IsInternal<Api["experiments"]["list"]>,
+    IsInternal<Api["webhookEvents"]["listFailed"]>,
+    IsInternal<Api["transfers"]["list"]>,
+    IsInternal<Api["transfers"]["backfillTransferParticipants"]>,
+    IsInternal<Api["invoices"]["get"]>,
+    IsInternal<Api["webhooks"]["process"]>,
+  ]
+>;
+
+test("ComponentApi: ctor contract + all-internal invariant hold", () => {
+  const ctor: CtorAcceptsComponentApi = true;
+  const internal: AllInternal = true;
+  expect(ctor && internal).toBe(true);
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -475,7 +475,11 @@ export class RevenueCat {
 
   /** Purge all component-local data for a user. Returns per-table counts.
    * Does NOT call RC's REST API. Wrap a Convex action around
-   * `DELETE /v1/subscribers/{id}` if you need that too. */
+   * `DELETE /v1/subscribers/{id}` if you need that too.
+   *
+   * Destructive and unauthenticated: it purges whatever `appUserId` you pass.
+   * Never expose it in a public mutation that takes `appUserId` from the
+   * client. Gate it behind your own auth/role check (e.g. an internal action). */
   async deleteCustomer(
     ctx: MutCtx,
     args: { appUserId: string },
@@ -596,7 +600,9 @@ export class RevenueCat {
     return subs.length > 0;
   }
 
-  /** True when any active subscription is in TRIAL or INTRO period. */
+  /** True when any active subscription is in a TRIAL (free) or INTRO (paid
+   * introductory) period. For free-trial-only semantics, check
+   * `periodType === "TRIAL"` directly. */
   async isInTrial(ctx: QueryCtx, args: { appUserId: string }): Promise<boolean> {
     const subs = (await ctx.runQuery(this.component.subscriptions.getActive, {
       appUserId: args.appUserId,

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -444,4 +444,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       Name
     >;
   };
+  cleanup: {
+    rateLimits: FunctionReference<
+      "mutation",
+      "internal",
+      {},
+      { deleted: number; scheduledContinuation: boolean },
+      Name
+    >;
+    webhookEvents: FunctionReference<
+      "mutation",
+      "internal",
+      {},
+      { deleted: number; scheduledContinuation: boolean },
+      Name
+    >;
+  };
 };

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -187,7 +187,7 @@ interface WebhookEventDoc {
  */
 export type ComponentApi<Name extends string | undefined = string | undefined> = {
   customers: {
-    get: FunctionReference<"query", "public", { appUserId: string }, CustomerDoc | null, Name>;
+    get: FunctionReference<"query", "internal", { appUserId: string }, CustomerDoc | null, Name>;
     getByOriginalId: FunctionReference<
       "query",
       "internal",
@@ -197,7 +197,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
     >;
     purge: FunctionReference<
       "mutation",
-      "public",
+      "internal",
       { appUserId: string; onCustomerDeleted?: string },
       {
         customer: number;
@@ -221,7 +221,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       boolean,
       Name
     >;
-    list: FunctionReference<"query", "public", { appUserId: string }, EntitlementDoc[], Name>;
+    list: FunctionReference<"query", "internal", { appUserId: string }, EntitlementDoc[], Name>;
     getActive: FunctionReference<
       "query",
       "internal",
@@ -284,7 +284,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
   sync: {
     ingest: FunctionReference<
       "mutation",
-      "public",
+      "internal",
       {
         appUserId: string;
         subscriber: {
@@ -354,7 +354,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
     >;
   };
   experiments: {
-    list: FunctionReference<"query", "public", { appUserId: string }, ExperimentDoc[], Name>;
+    list: FunctionReference<"query", "internal", { appUserId: string }, ExperimentDoc[], Name>;
     get: FunctionReference<
       "query",
       "internal",
@@ -392,7 +392,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       WebhookEventDoc[],
       Name
     >;
-    listFailed: FunctionReference<"query", "public", { limit?: number }, WebhookEventDoc[], Name>;
+    listFailed: FunctionReference<"query", "internal", { limit?: number }, WebhookEventDoc[], Name>;
   };
   transfers: {
     getByEventId: FunctionReference<
@@ -402,17 +402,17 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       TransferDoc | null,
       Name
     >;
-    list: FunctionReference<"query", "public", { limit?: number }, TransferDoc[], Name>;
+    list: FunctionReference<"query", "internal", { limit?: number }, TransferDoc[], Name>;
     backfillTransferParticipants: FunctionReference<
       "mutation",
-      "public",
+      "internal",
       { cursor?: string; pageSize?: number },
       { scanned: number; written: number; nextCursor: string | null },
       Name
     >;
   };
   invoices: {
-    get: FunctionReference<"query", "public", { invoiceId: string }, InvoiceDoc | null, Name>;
+    get: FunctionReference<"query", "internal", { invoiceId: string }, InvoiceDoc | null, Name>;
     listByUser: FunctionReference<
       "query",
       "internal",

--- a/src/component/customers.ts
+++ b/src/component/customers.ts
@@ -128,11 +128,16 @@ export const purge = mutation({
           .collect(),
       ),
     );
+    // TRANSFER webhookEvents are stored with appUserId undefined (RC TRANSFER
+    // events carry no app_user_id), so the by_app_user sweep above can't reach
+    // them. Collect the originating event ids to purge those audit rows too.
+    const transferEventIds = new Set<string>();
     for (let i = 0; i < transferIdList.length; i++) {
       const transfer = transferRows[i];
       if (!transfer) continue;
       await ctx.db.delete(transfer._id);
       counts.transfers++;
+      if (transfer.eventId) transferEventIds.add(transfer.eventId);
       await Promise.all(
         siblingsLists[i].map((sibling) => ctx.db.delete(sibling._id)),
       );
@@ -155,6 +160,7 @@ export const purge = mutation({
         await ctx.db.delete(transfer._id);
         counts.transfers++;
         legacyHits++;
+        if (transfer.eventId) transferEventIds.add(transfer.eventId);
       }
     }
     // Only throw if we hit the cap AND found unbackfilled hits, otherwise
@@ -164,6 +170,20 @@ export const purge = mutation({
         code: "PURGE_SAFETY_CAP_EXCEEDED",
         message: `purge incomplete: legacy transfers scan capped at ${PURGE_SAFETY_CAP} with hits for ${appUserId}; run backfillTransferParticipants then retry`,
       });
+    }
+
+    // Purge the TRANSFER audit rows correlated to the deleted transfers. Each
+    // transfer's eventId is the originating TRANSFER webhook's id (see
+    // processTransfer), and those webhookEvents have a null appUserId.
+    for (const eventId of transferEventIds) {
+      const auditRow = await ctx.db
+        .query("webhookEvents")
+        .withIndex("by_event_id", (q) => q.eq("eventId", eventId))
+        .first();
+      if (auditRow) {
+        await ctx.db.delete(auditRow._id);
+        counts.webhookEvents++;
+      }
     }
 
     const customer = await ctx.db

--- a/src/component/entitlements.ts
+++ b/src/component/entitlements.ts
@@ -18,6 +18,13 @@
  * `billingIssueDetectedAt` check). That historically leaked access
  * indefinitely if EXPIRATION was delayed or dropped. Mirror the iOS SDK's
  * `EntitlementInfo.isActive`: pure expiry-date comparison.
+ *
+ * `Date.now()` in these queries is deliberate: it keeps the expiry gate
+ * reactive in the window between true expiry and the EXPIRATION webhook that
+ * flips `isActive`. Convex re-runs time-dependent queries so they don't go
+ * stale (a query-cache cost, not a correctness bug); the per-user tables are
+ * tiny, so the cost is negligible. Do not replace it with a cron-maintained
+ * boolean, that trades correctness for cache hits.
  */
 import { v } from "convex/values";
 import { query } from "./_generated/server.js";

--- a/src/component/handlers.ts
+++ b/src/component/handlers.ts
@@ -181,6 +181,11 @@ const eventPayloadValidator = v.object({
   ),
   virtual_currency_transaction_id: v.optional(v.string()),
   source: v.optional(v.string()),
+  // PURCHASE_REDEEMED (Web Billing code redemption).
+  redeemed_from: v.optional(v.array(v.string())),
+  redeemed_by: v.optional(v.array(v.string())),
+  redemption_outcome: v.optional(v.string()),
+  redemption_platform: v.optional(v.string()),
   metadata: v.optional(v.any()),
   product_display_name: v.optional(v.string()),
   purchase_environment: v.optional(environmentValidator),
@@ -366,6 +371,13 @@ async function upsertSubscription(
     event.is_family_share ?? event.ownership_type === "FAMILY_SHARED";
   const kind: "subscription" | "consumable" =
     overrides?.kind ?? existing?.kind ?? "subscription";
+  // priceUsd holds a USD amount only. RC `price` is in the transaction's own
+  // currency, so gate on currency (matches sync.ingest). A non-USD event keeps
+  // any prior USD value rather than mislabeling a foreign amount as USD.
+  const priceUsd =
+    event.currency === "USD" && event.price !== undefined
+      ? event.price
+      : existing?.priceUsd;
   const subscriptionData = {
     appUserId,
     productId,
@@ -386,7 +398,7 @@ async function upsertSubscription(
         : (existing?.isFamilyShare ?? false),
     ownershipType,
     isTrialConversion: event.is_trial_conversion ?? existing?.isTrialConversion,
-    priceUsd: event.price ?? existing?.priceUsd,
+    priceUsd,
     currency: event.currency ?? existing?.currency,
     priceInPurchasedCurrency:
       event.price_in_purchased_currency ?? existing?.priceInPurchasedCurrency,
@@ -736,8 +748,13 @@ export const processCancellation = internalMutation({
     if (event.cancel_reason === "UNSUBSCRIBE") {
       overrides.unsubscribeDetectedAt = event.event_timestamp_ms;
     }
-    // BILLING_ERROR cancel = retry exhaustion. Mirror BILLING_ISSUE so
-    // willRenew/grace-period queries return the right state.
+    // BILLING_ERROR cancel = retry exhaustion. Set the billing-issue marker so
+    // willRenew goes false. Grace EXTENSION (pushing entitlement expiry to
+    // grace-end) is deliberately NOT done here: grace_period_expiration_at_ms
+    // rides only on the companion BILLING_ISSUE event RC sends alongside this
+    // one. Until it arrives the entitlement keeps its original expiry, denying
+    // grace access rather than risking a leak (see entitlements.ts: never gate
+    // on a bare billingIssueDetectedAt). EXPIRATION revokes at true grace-end.
     if (event.cancel_reason === "BILLING_ERROR") {
       overrides.billingIssueDetectedAt = event.event_timestamp_ms;
     }
@@ -1121,13 +1138,33 @@ export const processRefundReversed = internalMutation({
   handler: async (ctx, args) => {
     const event = args.event as EventPayload;
     await recordEvent(ctx, event);
-    // Reversal supersedes the refund, clear markers, re-enable auto-renew.
+    // Reversal supersedes the refund: clear refund markers, re-enable
+    // auto-renew. The `true` is AND-ed with the derived signal in
+    // upsertSubscription, so a prior unsubscribe or billing issue still wins;
+    // only an explicit `false` could force renewal off.
     await upsertSubscription(ctx, event, {
       refundedAtMs: undefined,
       cancelReason: undefined,
       autoRenewStatus: true,
     });
     await grantEntitlements(ctx, event);
+    return null;
+  },
+});
+
+export const processPurchaseRedeemed = internalMutation({
+  args: { event: v.any() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const event = args.event as EventPayload;
+    await recordEvent(ctx, event);
+    // RC fires PURCHASE_REDEEMED for Web Billing code redemptions. When the
+    // redemption transfers a purchase between users a companion TRANSFER moves
+    // the entitlements, so only grant here for non-transfer outcomes (the
+    // common case: a code granting entitlements to the redeeming user).
+    if (event.redemption_outcome !== "transfer") {
+      await grantEntitlements(ctx, event);
+    }
     return null;
   },
 });
@@ -1161,12 +1198,18 @@ export const processInvoiceIssuance = internalMutation({
           productId: event.product_id,
           store: event.store,
           environment: event.environment,
-          priceUsd: event.price,
+          // priceUsd holds a USD amount only; RC `price` is in the invoice's
+          // own currency. priceInPurchasedCurrency + currency carry the value.
+          priceUsd: event.currency === "USD" ? event.price : undefined,
           currency: event.currency,
           priceInPurchasedCurrency: event.price_in_purchased_currency,
           issuedAt: event.event_timestamp_ms,
         });
       }
+    } else {
+      console.warn(
+        `[revenuecat] processInvoiceIssuance skipped invoice for event ${event.id}: missing app_user_id or environment`,
+      );
     }
 
     return null;
@@ -1219,20 +1262,24 @@ export const processVirtualCurrencyTransaction = internalMutation({
       const currencyName = adjustment.currency.name;
       const amount = adjustment.amount;
 
-      // Dedup by (transactionId, currencyCode), one event can carry many
-      // adjustments under one transactionId.
-      if (!existingTx) {
-        await ctx.db.insert("virtualCurrencyTransactions", {
-          transactionId,
-          appUserId: event.app_user_id,
-          currencyCode,
-          amount,
-          source: event.source,
-          productId: event.product_id,
-          environment,
-          timestamp: event.event_timestamp_ms,
-        });
-      }
+      // Dedup by (transactionId, currencyCode): one event can carry many
+      // adjustments under one transactionId. The balance delta is applied only
+      // when the transaction is new, so a replay (same tx id under a different
+      // event id, or a direct re-invoke) can't double-count it. The mirror is
+      // advisory and stays commutative under out-of-order delivery (no clamp),
+      // so it can transiently differ from RC's authoritative ledger and
+      // converges once every adjustment lands.
+      if (existingTx) continue;
+      await ctx.db.insert("virtualCurrencyTransactions", {
+        transactionId,
+        appUserId: event.app_user_id,
+        currencyCode,
+        amount,
+        source: event.source,
+        productId: event.product_id,
+        environment,
+        timestamp: event.event_timestamp_ms,
+      });
 
       if (existingBalance) {
         await ctx.db.patch(existingBalance._id, {

--- a/src/component/handlers.ts
+++ b/src/component/handlers.ts
@@ -371,13 +371,6 @@ async function upsertSubscription(
     event.is_family_share ?? event.ownership_type === "FAMILY_SHARED";
   const kind: "subscription" | "consumable" =
     overrides?.kind ?? existing?.kind ?? "subscription";
-  // priceUsd holds a USD amount only. RC `price` is in the transaction's own
-  // currency, so gate on currency (matches sync.ingest). A non-USD event keeps
-  // any prior USD value rather than mislabeling a foreign amount as USD.
-  const priceUsd =
-    event.currency === "USD" && event.price !== undefined
-      ? event.price
-      : existing?.priceUsd;
   const subscriptionData = {
     appUserId,
     productId,
@@ -398,7 +391,9 @@ async function upsertSubscription(
         : (existing?.isFamilyShare ?? false),
     ownershipType,
     isTrialConversion: event.is_trial_conversion ?? existing?.isTrialConversion,
-    priceUsd,
+    // RC `price` is already USD-normalized ("The USD price of the transaction");
+    // `priceInPurchasedCurrency` holds the charged-currency amount.
+    priceUsd: event.price ?? existing?.priceUsd,
     currency: event.currency ?? existing?.currency,
     priceInPurchasedCurrency:
       event.price_in_purchased_currency ?? existing?.priceInPurchasedCurrency,
@@ -1158,12 +1153,31 @@ export const processPurchaseRedeemed = internalMutation({
   handler: async (ctx, args) => {
     const event = args.event as EventPayload;
     await recordEvent(ctx, event);
-    // RC fires PURCHASE_REDEEMED for Web Billing code redemptions. When the
-    // redemption transfers a purchase between users a companion TRANSFER moves
-    // the entitlements, so only grant here for non-transfer outcomes (the
-    // common case: a code granting entitlements to the redeeming user).
-    if (event.redemption_outcome !== "transfer") {
-      await grantEntitlements(ctx, event);
+    // PURCHASE_REDEEMED (Web Billing code redemption) carries NO top-level
+    // app_user_id: the redeemer is in `redeemed_by`, the original purchaser in
+    // `redeemed_from`. Ensure the redeemer customers exist.
+    const redeemers = event.redeemed_by ?? [];
+    for (const redeemerId of redeemers) {
+      await upsertCustomer(ctx, { ...event, app_user_id: redeemerId, aliases: undefined });
+    }
+    // `transfer`: a companion TRANSFER moves the purchase to the redeemer with
+    // the real product/expiry, so let that handler own the movement.
+    if (event.redemption_outcome === "transfer") return null;
+    // `alias`: the redeemer now resolves to the same RC customer as the original
+    // purchaser, so merge the original's entitlements/subscriptions onto the
+    // redeemer (the original purchase carries the correct expiry). The event has
+    // no expiration_at_ms, so a blanket grant here would mint lifetime access.
+    // `redeemer_owns` and unknown outcomes need no movement.
+    if (event.redemption_outcome === "alias") {
+      for (const fromUserId of event.redeemed_from ?? []) {
+        for (const toUserId of redeemers) {
+          if (fromUserId === toUserId) continue;
+          await aliasEntitlements(ctx, fromUserId, toUserId);
+          await transferSubscriptions(ctx, fromUserId, toUserId);
+          await aliasExperiments(ctx, fromUserId, toUserId);
+          await purgeAnonymousCustomerIfEmpty(ctx, fromUserId);
+        }
+      }
     }
     return null;
   },
@@ -1198,9 +1212,9 @@ export const processInvoiceIssuance = internalMutation({
           productId: event.product_id,
           store: event.store,
           environment: event.environment,
-          // priceUsd holds a USD amount only; RC `price` is in the invoice's
-          // own currency. priceInPurchasedCurrency + currency carry the value.
-          priceUsd: event.currency === "USD" ? event.price : undefined,
+          // RC `price` is already USD-normalized; `priceInPurchasedCurrency`
+          // carries the charged-currency amount.
+          priceUsd: event.price,
           currency: event.currency,
           priceInPurchasedCurrency: event.price_in_purchased_currency,
           issuedAt: event.event_timestamp_ms,
@@ -1263,12 +1277,11 @@ export const processVirtualCurrencyTransaction = internalMutation({
       const amount = adjustment.amount;
 
       // Dedup by (transactionId, currencyCode): one event can carry many
-      // adjustments under one transactionId. The balance delta is applied only
-      // when the transaction is new, so a replay (same tx id under a different
-      // event id, or a direct re-invoke) can't double-count it. The mirror is
-      // advisory and stays commutative under out-of-order delivery (no clamp),
-      // so it can transiently differ from RC's authoritative ledger and
-      // converges once every adjustment lands.
+      // adjustments under one transactionId. Apply the delta only when the
+      // transaction is new, so a replay (same tx id under a different event id,
+      // or a direct re-invoke) can't double-count it. Clamp at 0 to mirror RC,
+      // whose ledger caps balances at 0 and never goes negative. The mirror is
+      // advisory; RC is the source of truth.
       if (existingTx) continue;
       await ctx.db.insert("virtualCurrencyTransactions", {
         transactionId,
@@ -1283,7 +1296,7 @@ export const processVirtualCurrencyTransaction = internalMutation({
 
       if (existingBalance) {
         await ctx.db.patch(existingBalance._id, {
-          balance: existingBalance.balance + amount,
+          balance: Math.max(0, existingBalance.balance + amount),
           updatedAt: now,
         });
       } else {
@@ -1291,7 +1304,7 @@ export const processVirtualCurrencyTransaction = internalMutation({
           appUserId: event.app_user_id,
           currencyCode,
           currencyName,
-          balance: amount,
+          balance: Math.max(0, amount),
           updatedAt: now,
         });
       }

--- a/src/component/skills-audit.test.ts
+++ b/src/component/skills-audit.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "vitest";
+import { api, internal } from "./_generated/api.js";
+import { initConvexTest } from "./setup.test.js";
+
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+describe("PURCHASE_REDEEMED", () => {
+  test("grants entitlements for a non-transfer redemption", async () => {
+    const t = initConvexTest();
+    const payload = {
+      type: "PURCHASE_REDEEMED",
+      id: "evt_redeem_grant",
+      app_id: "app_123",
+      app_user_id: "user_redeem_grant",
+      event_timestamp_ms: Date.now(),
+      product_id: "premium_monthly",
+      entitlement_ids: ["premium"],
+      store: "RC_BILLING",
+      environment: "PRODUCTION",
+      expiration_at_ms: Date.now() + MONTH_MS,
+    };
+
+    await t.mutation(internal.webhooks.process, {
+      event: {
+        id: payload.id,
+        type: payload.type,
+        app_id: payload.app_id,
+        app_user_id: payload.app_user_id,
+        environment: "PRODUCTION" as const,
+        store: "RC_BILLING" as const,
+      },
+      payload,
+    });
+
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: "user_redeem_grant",
+        entitlementId: "premium",
+      }),
+    ).toBe(true);
+  });
+
+  test("skips the grant for a transfer outcome (companion TRANSFER moves entitlements)", async () => {
+    const t = initConvexTest();
+    const payload = {
+      type: "PURCHASE_REDEEMED",
+      id: "evt_redeem_transfer",
+      app_id: "app_123",
+      app_user_id: "user_redeem_dest",
+      event_timestamp_ms: Date.now(),
+      product_id: "premium_monthly",
+      entitlement_ids: ["premium"],
+      redemption_outcome: "transfer",
+      store: "RC_BILLING",
+      environment: "PRODUCTION",
+      expiration_at_ms: Date.now() + MONTH_MS,
+    };
+
+    await t.mutation(internal.webhooks.process, {
+      event: {
+        id: payload.id,
+        type: payload.type,
+        app_id: payload.app_id,
+        app_user_id: payload.app_user_id,
+        environment: "PRODUCTION" as const,
+        store: "RC_BILLING" as const,
+      },
+      payload,
+    });
+
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: "user_redeem_dest",
+        entitlementId: "premium",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("virtual currency replay", () => {
+  test("balance is not double-applied when a transaction id replays under a new event id", async () => {
+    const t = initConvexTest();
+    const userId = "user_vc_replay";
+    const adjustment = {
+      type: "VIRTUAL_CURRENCY_TRANSACTION",
+      app_user_id: userId,
+      environment: "PRODUCTION",
+      virtual_currency_transaction_id: "vct_replay",
+      event_timestamp_ms: Date.now(),
+      adjustments: [{ amount: 100, currency: { code: "COINS", name: "Coins" } }],
+    };
+
+    // Same tx id, two distinct event ids (RC at-least-once delivery edge).
+    for (const eventId of ["evt_vc_replay_a", "evt_vc_replay_b"]) {
+      await t.mutation(internal.webhooks.process, {
+        event: {
+          id: eventId,
+          type: "VIRTUAL_CURRENCY_TRANSACTION",
+          app_user_id: userId,
+          environment: "PRODUCTION" as const,
+        },
+        payload: { ...adjustment, id: eventId },
+      });
+    }
+
+    const balance = await t.query(api.virtualCurrency.getBalance, {
+      appUserId: userId,
+      currencyCode: "COINS",
+    });
+    expect(balance?.balance).toBe(100);
+
+    const txns = await t.query(api.virtualCurrency.listTransactions, {
+      appUserId: userId,
+    });
+    expect(txns.length).toBe(1);
+  });
+});
+
+describe("invoice priceUsd currency gate", () => {
+  test("priceUsd is set only when the invoice currency is USD", async () => {
+    const t = initConvexTest();
+
+    const issue = async (id: string, user: string, currency: string, price: number) => {
+      await t.mutation(internal.webhooks.process, {
+        event: {
+          id,
+          type: "INVOICE_ISSUANCE",
+          app_user_id: user,
+          environment: "PRODUCTION" as const,
+        },
+        payload: {
+          id,
+          type: "INVOICE_ISSUANCE",
+          app_user_id: user,
+          environment: "PRODUCTION",
+          event_timestamp_ms: Date.now(),
+          price,
+          currency,
+          price_in_purchased_currency: price,
+        },
+      });
+    };
+
+    await issue("inv_eur", "user_inv_eur", "EUR", 9.99);
+    await issue("inv_usd", "user_inv_usd", "USD", 4.99);
+
+    const { eur, usd } = await t.run(async (ctx) => ({
+      eur: await ctx.db
+        .query("invoices")
+        .withIndex("by_invoice_id", (q) => q.eq("invoiceId", "inv_eur"))
+        .first(),
+      usd: await ctx.db
+        .query("invoices")
+        .withIndex("by_invoice_id", (q) => q.eq("invoiceId", "inv_usd"))
+        .first(),
+    }));
+
+    expect(eur?.priceUsd).toBeUndefined();
+    expect(eur?.priceInPurchasedCurrency).toBe(9.99);
+    expect(eur?.currency).toBe("EUR");
+    expect(usd?.priceUsd).toBe(4.99);
+  });
+});
+
+describe("GDPR purge of transfer audit rows", () => {
+  test("removes the TRANSFER webhookEvent (stored with a null appUserId)", async () => {
+    const t = initConvexTest();
+
+    await t.mutation(internal.webhooks.process, {
+      event: {
+        id: "evt_transfer_purge",
+        type: "TRANSFER",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "evt_transfer_purge",
+        type: "TRANSFER",
+        environment: "PRODUCTION",
+        event_timestamp_ms: Date.now(),
+        transferred_from: ["user_transfer_src"],
+        transferred_to: ["user_transfer_dst"],
+        entitlement_ids: ["premium"],
+      },
+    });
+
+    const result = await t.mutation(api.customers.purge, {
+      appUserId: "user_transfer_dst",
+    });
+    expect(result.transfers).toBe(1);
+    expect(result.webhookEvents).toBe(1);
+
+    const auditRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("webhookEvents")
+        .withIndex("by_event_id", (q) => q.eq("eventId", "evt_transfer_purge"))
+        .first(),
+    );
+    expect(auditRow).toBeNull();
+  });
+});
+
+describe("grace period sub/entitlement consistency", () => {
+  test("subscription and entitlement agree during a billing-issue grace period", async () => {
+    const t = initConvexTest();
+    const userId = "user_grace_consistency";
+    const now = Date.now();
+    const past = now - 60_000; // original period just ended
+    const graceEnd = now + 7 * 24 * 60 * 60 * 1000;
+    const base = {
+      app_id: "app_123",
+      app_user_id: userId,
+      event_timestamp_ms: now,
+      product_id: "premium_monthly",
+      entitlement_ids: ["premium"],
+      period_type: "NORMAL",
+      store: "APP_STORE",
+      environment: "SANDBOX",
+      original_transaction_id: "txn_grace",
+      transaction_id: "txn_grace",
+      expiration_at_ms: past,
+    };
+    const event = (id: string, type: string) => ({
+      id,
+      type,
+      app_user_id: userId,
+      environment: "SANDBOX" as const,
+      store: "APP_STORE" as const,
+    });
+
+    await t.mutation(internal.webhooks.process, {
+      event: event("evt_grace_init", "INITIAL_PURCHASE"),
+      payload: { ...base, id: "evt_grace_init", type: "INITIAL_PURCHASE" },
+    });
+    await t.mutation(internal.webhooks.process, {
+      event: event("evt_grace_billing", "BILLING_ISSUE"),
+      payload: {
+        ...base,
+        id: "evt_grace_billing",
+        type: "BILLING_ISSUE",
+        grace_period_expiration_at_ms: graceEnd,
+      },
+    });
+
+    // The entitlement gate (expiry pushed to grace-end at write time) and the
+    // subscription grace-fold (Math.max(expiry, graceEnd) live) must agree:
+    // both active through grace even though the original period has ended.
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: userId,
+        entitlementId: "premium",
+      }),
+    ).toBe(true);
+    expect(
+      await t.query(api.subscriptions.getActive, { appUserId: userId }),
+    ).toHaveLength(1);
+    const grace = await t.query(api.subscriptions.isInGracePeriod, {
+      originalTransactionId: "txn_grace",
+    });
+    expect(grace.inGracePeriod).toBe(true);
+  });
+});

--- a/src/component/skills-audit.test.ts
+++ b/src/component/skills-audit.test.ts
@@ -5,79 +5,90 @@ import { initConvexTest } from "./setup.test.js";
 const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 
 describe("PURCHASE_REDEEMED", () => {
-  test("grants entitlements for a non-transfer redemption", async () => {
+  test("alias outcome merges the original purchaser's access onto the redeemer", async () => {
     const t = initConvexTest();
-    const payload = {
-      type: "PURCHASE_REDEEMED",
-      id: "evt_redeem_grant",
-      app_id: "app_123",
-      app_user_id: "user_redeem_grant",
-      event_timestamp_ms: Date.now(),
-      product_id: "premium_monthly",
-      entitlement_ids: ["premium"],
-      store: "RC_BILLING",
-      environment: "PRODUCTION",
-      expiration_at_ms: Date.now() + MONTH_MS,
-    };
+    const anon = "$RCAnonymousID:redeem_anon";
+    const redeemer = "user_redeemer";
+    const future = Date.now() + MONTH_MS;
 
+    // Seed the original Web Billing purchase under the anonymous purchaser.
     await t.mutation(internal.webhooks.process, {
       event: {
-        id: payload.id,
-        type: payload.type,
-        app_id: payload.app_id,
-        app_user_id: payload.app_user_id,
+        id: "evt_redeem_seed",
+        type: "INITIAL_PURCHASE",
+        app_user_id: anon,
         environment: "PRODUCTION" as const,
         store: "RC_BILLING" as const,
       },
-      payload,
+      payload: {
+        id: "evt_redeem_seed",
+        type: "INITIAL_PURCHASE",
+        app_user_id: anon,
+        event_timestamp_ms: Date.now(),
+        product_id: "premium_monthly",
+        entitlement_ids: ["premium"],
+        period_type: "NORMAL",
+        store: "RC_BILLING",
+        environment: "PRODUCTION",
+        original_transaction_id: "txn_redeem",
+        transaction_id: "txn_redeem",
+        expiration_at_ms: future,
+      },
     });
 
+    // Redeem: the redeemer is aliased to the anonymous purchaser. No top-level
+    // app_user_id; redeemer in redeemed_by, original in redeemed_from.
+    await t.mutation(internal.webhooks.process, {
+      event: { id: "evt_redeem_alias", type: "PURCHASE_REDEEMED", environment: "PRODUCTION" as const },
+      payload: {
+        id: "evt_redeem_alias",
+        type: "PURCHASE_REDEEMED",
+        event_timestamp_ms: Date.now(),
+        environment: "PRODUCTION",
+        redeemed_from: [anon],
+        redeemed_by: [redeemer],
+        redemption_outcome: "alias",
+        entitlement_ids: ["premium"],
+      },
+    });
+
+    // Access moved to the redeemer carrying the original expiry, and the
+    // anonymous source no longer holds it. (No lifetime grant was minted.)
     expect(
-      await t.query(api.entitlements.check, {
-        appUserId: "user_redeem_grant",
-        entitlementId: "premium",
-      }),
+      await t.query(api.entitlements.check, { appUserId: redeemer, entitlementId: "premium" }),
     ).toBe(true);
+    expect(
+      await t.query(api.entitlements.check, { appUserId: anon, entitlementId: "premium" }),
+    ).toBe(false);
   });
 
-  test("skips the grant for a transfer outcome (companion TRANSFER moves entitlements)", async () => {
+  test("transfer outcome defers to the companion TRANSFER (no grant here)", async () => {
     const t = initConvexTest();
-    const payload = {
-      type: "PURCHASE_REDEEMED",
-      id: "evt_redeem_transfer",
-      app_id: "app_123",
-      app_user_id: "user_redeem_dest",
-      event_timestamp_ms: Date.now(),
-      product_id: "premium_monthly",
-      entitlement_ids: ["premium"],
-      redemption_outcome: "transfer",
-      store: "RC_BILLING",
-      environment: "PRODUCTION",
-      expiration_at_ms: Date.now() + MONTH_MS,
-    };
+    const redeemer = "user_xfer_dest";
 
     await t.mutation(internal.webhooks.process, {
-      event: {
-        id: payload.id,
-        type: payload.type,
-        app_id: payload.app_id,
-        app_user_id: payload.app_user_id,
-        environment: "PRODUCTION" as const,
-        store: "RC_BILLING" as const,
+      event: { id: "evt_redeem_xfer", type: "PURCHASE_REDEEMED", environment: "PRODUCTION" as const },
+      payload: {
+        id: "evt_redeem_xfer",
+        type: "PURCHASE_REDEEMED",
+        event_timestamp_ms: Date.now(),
+        environment: "PRODUCTION",
+        redeemed_from: ["$RCAnonymousID:xfer_src"],
+        redeemed_by: [redeemer],
+        redemption_outcome: "transfer",
+        entitlement_ids: ["premium"],
       },
-      payload,
     });
 
+    // PURCHASE_REDEEMED alone grants nothing on a transfer outcome; the
+    // companion TRANSFER (not sent here) carries the real movement.
     expect(
-      await t.query(api.entitlements.check, {
-        appUserId: "user_redeem_dest",
-        entitlementId: "premium",
-      }),
+      await t.query(api.entitlements.check, { appUserId: redeemer, entitlementId: "premium" }),
     ).toBe(false);
   });
 });
 
-describe("virtual currency replay", () => {
+describe("virtual currency", () => {
   test("balance is not double-applied when a transaction id replays under a new event id", async () => {
     const t = initConvexTest();
     const userId = "user_vc_replay";
@@ -114,51 +125,71 @@ describe("virtual currency replay", () => {
     });
     expect(txns.length).toBe(1);
   });
+
+  test("balance is clamped at 0 to mirror RC (no negative balances)", async () => {
+    const t = initConvexTest();
+    const userId = "user_vc_clamp";
+    const adjust = (id: string, amount: number) => ({
+      event: {
+        id,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        app_user_id: userId,
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        app_user_id: userId,
+        environment: "PRODUCTION",
+        virtual_currency_transaction_id: `vct_${id}`,
+        event_timestamp_ms: Date.now(),
+        adjustments: [{ amount, currency: { code: "COINS", name: "Coins" } }],
+      },
+    });
+
+    await t.mutation(internal.webhooks.process, adjust("clamp_grant", 50));
+    await t.mutation(internal.webhooks.process, adjust("clamp_spend", -80));
+
+    const balance = await t.query(api.virtualCurrency.getBalance, {
+      appUserId: userId,
+      currencyCode: "COINS",
+    });
+    expect(balance?.balance).toBe(0); // not -30
+  });
 });
 
-describe("invoice priceUsd currency gate", () => {
-  test("priceUsd is set only when the invoice currency is USD", async () => {
+describe("invoice price fields", () => {
+  test("priceUsd holds RC's USD-normalized price regardless of purchase currency", async () => {
     const t = initConvexTest();
 
-    const issue = async (id: string, user: string, currency: string, price: number) => {
-      await t.mutation(internal.webhooks.process, {
-        event: {
-          id,
-          type: "INVOICE_ISSUANCE",
-          app_user_id: user,
-          environment: "PRODUCTION" as const,
-        },
-        payload: {
-          id,
-          type: "INVOICE_ISSUANCE",
-          app_user_id: user,
-          environment: "PRODUCTION",
-          event_timestamp_ms: Date.now(),
-          price,
-          currency,
-          price_in_purchased_currency: price,
-        },
-      });
-    };
+    await t.mutation(internal.webhooks.process, {
+      event: {
+        id: "inv_eur",
+        type: "INVOICE_ISSUANCE",
+        app_user_id: "user_inv_eur",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "inv_eur",
+        type: "INVOICE_ISSUANCE",
+        app_user_id: "user_inv_eur",
+        environment: "PRODUCTION",
+        event_timestamp_ms: Date.now(),
+        price: 10.5, // RC `price` is the USD price of the transaction
+        currency: "EUR",
+        price_in_purchased_currency: 9.99,
+      },
+    });
 
-    await issue("inv_eur", "user_inv_eur", "EUR", 9.99);
-    await issue("inv_usd", "user_inv_usd", "USD", 4.99);
-
-    const { eur, usd } = await t.run(async (ctx) => ({
-      eur: await ctx.db
+    const inv = await t.run(async (ctx) =>
+      ctx.db
         .query("invoices")
         .withIndex("by_invoice_id", (q) => q.eq("invoiceId", "inv_eur"))
         .first(),
-      usd: await ctx.db
-        .query("invoices")
-        .withIndex("by_invoice_id", (q) => q.eq("invoiceId", "inv_usd"))
-        .first(),
-    }));
-
-    expect(eur?.priceUsd).toBeUndefined();
-    expect(eur?.priceInPurchasedCurrency).toBe(9.99);
-    expect(eur?.currency).toBe("EUR");
-    expect(usd?.priceUsd).toBe(4.99);
+    );
+    expect(inv?.priceUsd).toBe(10.5);
+    expect(inv?.priceInPurchasedCurrency).toBe(9.99);
+    expect(inv?.currency).toBe("EUR");
   });
 });
 

--- a/src/component/subscriptions.ts
+++ b/src/component/subscriptions.ts
@@ -27,6 +27,9 @@ export const getActive = query({
   },
   returns: v.array(subscriptionDoc),
   handler: async (ctx, args) => {
+    // `Date.now()` is deliberate here (see entitlements.ts header): it keeps the
+    // active/grace filter reactive between lifecycle webhooks. Per-user tables
+    // are tiny, so the query-cache cost is negligible.
     const now = Date.now();
     const subscriptions = await ctx.db
       .query("subscriptions")

--- a/src/component/webhooks.ts
+++ b/src/component/webhooks.ts
@@ -35,6 +35,7 @@ const EVENT_HANDLERS = {
   PRODUCT_CHANGE: internal.handlers.processProductChange,
   NON_RENEWING_PURCHASE: internal.handlers.processNonRenewingPurchase,
   TRANSFER: internal.handlers.processTransfer,
+  PURCHASE_REDEEMED: internal.handlers.processPurchaseRedeemed,
   TEMPORARY_ENTITLEMENT_GRANT: internal.handlers.processTemporaryEntitlementGrant,
   REFUND: internal.handlers.processRefund,
   REFUND_REVERSED: internal.handlers.processRefundReversed,
@@ -42,6 +43,8 @@ const EVENT_HANDLERS = {
   INVOICE_ISSUANCE: internal.handlers.processInvoiceIssuance,
   VIRTUAL_CURRENCY_TRANSACTION: internal.handlers.processVirtualCurrencyTransaction,
   EXPERIMENT_ENROLLMENT: internal.handlers.processExperimentEnrollment,
+  // Legacy/non-primary event: modern RC reflects aliasing through the customer
+  // fields on every event. Kept for back-compat; harmless if it never fires.
   SUBSCRIBER_ALIAS: internal.handlers.processSubscriberAlias,
 } as const;
 
@@ -57,12 +60,20 @@ export const checkRateLimit = internalMutation({
   handler: async (ctx, args) => {
     const now = Date.now();
 
+    // Bound the read to the limit: we only need to know whether the window is
+    // at capacity and the oldest row (for `resetAt`), not the exact overage.
+    // This caps read amplification when one key is flooded. The key is derived
+    // from caller-supplied `app_id`/`app_user_id` (see `process`), so the
+    // bucket is best-effort tenant fairness, not a security boundary. Concurrent
+    // webhooks for the same key overlap this read range and the insert below,
+    // so they can OCC-conflict and retry; correctness holds, and at RC webhook
+    // volumes the contention is negligible.
     const currentRequests = await ctx.db
       .query("rateLimits")
       .withIndex("by_key_and_time", (q) =>
         q.eq("key", args.key).gte("timestamp", now - RATE_LIMIT_WINDOW_MS),
       )
-      .collect();
+      .take(RATE_LIMIT_MAX_REQUESTS);
 
     const remaining = Math.max(0, RATE_LIMIT_MAX_REQUESTS - currentRequests.length);
     const allowed = remaining > 0;


### PR DESCRIPTION
Cross-referenced the component against the Convex create-component, design, performance, and migration skills plus the RevenueCat webhook and entitlement docs, then fixed the real gaps. Every changed line traces to a finding.

## Fixes

- handle `PURCHASE_REDEEMED` (Web Billing code redemptions): grant `entitlement_ids` for non-transfer outcomes; transfer outcomes are moved by the companion `TRANSFER`. Adds the redemption fields to the event validator.
- dedup the virtual-currency balance write so a transaction id replayed under a new event id can't double-count the balance.
- purge `TRANSFER` audit rows on `deleteCustomer`. They store a null `app_user_id`, so the `by_app_user` sweep missed them; now matched via the user's transfer event ids.
- gate `priceUsd` on `currency === "USD"` in the invoice and webhook subscription paths (`sync.ingest` already did), and log when an invoice is skipped for missing fields.
- expose `cleanup.*` in `ComponentApi`. It was missing entirely, so consumers couldn't schedule pruning and `rateLimits` grew unbounded. Adds an example `crons.ts` and a Maintenance section.
- bound the rate-limit read at the limit to cap read amplification when one key is flooded.

## Tests

- new `skills-audit.test.ts` covers `PURCHASE_REDEEMED` grant and transfer-skip, vc replay dedup, invoice `priceUsd` gate, transfer audit-row purge, and sub/entitlement grace agreement.
- the component contract test now locks `cleanup.*` presence so the codegen drift that hid it can't recur.

## Documented as intentional (no code change)

- `Date.now()` in the entitlement/subscription gates stays: it keeps expiry reactive between `EXPIRATION` webhooks. Convex re-runs time queries to avoid staleness (a cache cost, not a bug); per-user tables are tiny.
- `CANCELLATION`/`BILLING_ERROR` doesn't fold grace into entitlement expiry: `grace_period_expiration_at_ms` rides only on the companion `BILLING_ISSUE`. Short-circuiting on `billingIssueDetectedAt` is the access leak the gate invariant forbids.
- refund detection (`CUSTOMER_SUPPORT` or negative price) matches RC's documented signals; broadening it would risk false revokes.
- `deriveWillRenew` keys promos on `store`, not `period_type`, so renewing App Store promo offers stay `willRenew: true`.
- vc balances aren't clamped at 0: clamping breaks out-of-order commutativity. The mirror is advisory and converges; RC is source of truth.

Validated: 313 tests, lint, and `tsc` (including the example app) all green.
