### PR TITLE
fix(component): restore the public api so consumers can build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,20 @@
 [![npm](https://img.shields.io/npm/v/convex-revenuecat)](https://www.npmjs.com/package/convex-revenuecat)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-I use RevenueCat for in-app purchases and Convex for everything else. Needed a way to check entitlements server-side without hitting RevenueCat's API on every request. So I built a Convex component that receives RevenueCat webhooks and keeps subscription state in your database. Query it like any other Convex table, get real-time reactivity for free.
+I use RevenueCat for in-app purchases and Convex for everything else. Needed a
+way to check entitlements server-side without hitting RevenueCat's API on every
+request. So I built a Convex component that receives RevenueCat webhooks and
+keeps subscription state in your database. Query it like any other Convex table,
+get real-time reactivity for free.
 
-Handles all webhook event types RevenueCat emits, deduplicates by event ID, and gets the edge cases right: cancellation keeps access until expiration, pause doesn't revoke, grace periods stay active, and refunds (CANCELLATION with `cancel_reason: "CUSTOMER_SUPPORT"`) revoke immediately.
+Handles all webhook event types RevenueCat emits, deduplicates by event ID, and
+gets the edge cases right: cancellation keeps access until expiration, pause
+doesn't revoke, grace periods stay active, and refunds (CANCELLATION with
+`cancel_reason: "CUSTOMER_SUPPORT"`) revoke immediately.
 
-This is not a replacement for the [RevenueCat SDK](https://www.revenuecat.com/docs/getting-started/installation). Use their SDK client-side for purchases. This handles the server-side state.
+This is not a replacement for the
+[RevenueCat SDK](https://www.revenuecat.com/docs/getting-started/installation).
+Use their SDK client-side for purchases. This handles the server-side state.
 
 ## Install
 
@@ -55,7 +64,10 @@ revenuecat.registerRoutes(http);
 export default http;
 ```
 
-`registerRoutes(http)` defaults to `POST /webhooks/revenuecat`. Pass `{ path: "/custom/path" }` to mount elsewhere. The longer `http.route({ path, method: "POST", handler: revenuecat.httpHandler() })` form still works.
+`registerRoutes(http)` defaults to `POST /webhooks/revenuecat`. Pass
+`{ path: "/custom/path" }` to mount elsewhere. The longer
+`http.route({ path, method: "POST", handler: revenuecat.httpHandler() })` form
+still works.
 
 ### 3. Set the env variable
 
@@ -64,11 +76,16 @@ openssl rand -base64 32
 npx convex env set REVENUECAT_WEBHOOK_AUTH "your-generated-secret"
 ```
 
-A secret that's present but shorter than 32 characters (after stripping any `Bearer ` prefix and whitespace) throws at construction and fails the deploy. A missing secret doesn't fail the deploy. The handler rejects every webhook with a 500 until you set it. RevenueCat doesn't sign payloads, so the shared secret is the entire security boundary. An unauthenticated request is never processed.
+A secret that's present but shorter than 32 characters (after stripping any
+`Bearer ` prefix and whitespace) throws at construction and fails the deploy. A
+missing secret doesn't fail the deploy. The handler rejects every webhook with a
+500 until you set it. RevenueCat doesn't sign payloads, so the shared secret is
+the entire security boundary. An unauthenticated request is never processed.
 
 ### 4. Configure RevenueCat
 
-In the [RevenueCat Dashboard](https://app.revenuecat.com), go to Project Settings > Integrations > Webhooks > + New:
+In the [RevenueCat Dashboard](https://app.revenuecat.com), go to Project
+Settings > Integrations > Webhooks > + New:
 
 - Webhook URL: `https://<your-deployment>.convex.site/webhooks/revenuecat`
 - Authorization header: the secret from step 3
@@ -89,13 +106,22 @@ export const revenuecat = new RevenueCat(components.revenuecat, {
 
 ### Authorize every query
 
-Never accept `appUserId` as a function argument. Derive it from `ctx.auth.getUserIdentity()` server-side. Accepting it from the client is an IDOR: any caller can read any other user's subscription state by passing their ID. Convex's own AI guidelines spell this out: "NEVER accept a `userId` or any user identifier as a function argument for authorization purposes."
+Never accept `appUserId` as a function argument. Derive it from
+`ctx.auth.getUserIdentity()` server-side. Accepting it from the client is an
+IDOR: any caller can read any other user's subscription state by passing their
+ID. Convex's own AI guidelines spell this out: "NEVER accept a `userId` or any
+user identifier as a function argument for authorization purposes."
 
-The snippets below assume `identity.subject` is the same string the mobile app passes to `Purchases.configure(...)` or `Purchases.logIn(...)`. If your auth provider's `subject` and your RC `appUserId` differ, look up the mapping from a `users` table keyed by `identity.tokenIdentifier` instead.
+The snippets below assume `identity.subject` is the same string the mobile app
+passes to `Purchases.configure(...)` or `Purchases.logIn(...)`. If your auth
+provider's `subject` and your RC `appUserId` differ, look up the mapping from a
+`users` table keyed by `identity.tokenIdentifier` instead.
 
 #### Use `revenuecat.api()` to skip the boilerplate
 
-The `api()` factory returns identity-aware query handlers you can spread into your `convex/` file. Each handler resolves the caller's `appUserId` server-side, so the IDOR class is closed by construction:
+The `api()` factory returns identity-aware query handlers you can spread into
+your `convex/` file. Each handler resolves the caller's `appUserId` server-side,
+so the IDOR class is closed by construction:
 
 ```typescript
 // convex/revenuecat.ts
@@ -135,7 +161,12 @@ export const {
 } = revenuecat.api();
 ```
 
-Then from React: `useQuery(api.revenuecat.isSubscriber, {})`. The factory covers every user-scoped query the client exposes. Cross-user lookups (`isInGracePeriod` by transaction id, `getTransfer`/`getInvoice` by id) stay off `api()` because they belong in role-gated `internalQuery`s, not auth-anywhere endpoints. Override the resolver with the `getAppUserId` option when your auth identity and RevenueCat app-user-id are different strings:
+Then from React: `useQuery(api.revenuecat.isSubscriber, {})`. The factory covers
+every user-scoped query the client exposes. Cross-user lookups
+(`isInGracePeriod` by transaction id, `getTransfer`/`getInvoice` by id) stay off
+`api()` because they belong in role-gated `internalQuery`s, not auth-anywhere
+endpoints. Override the resolver with the `getAppUserId` option when your auth
+identity and RevenueCat app-user-id are different strings:
 
 ```typescript
 new RevenueCat(components.revenuecat, {
@@ -145,7 +176,9 @@ new RevenueCat(components.revenuecat, {
     if (!identity) throw new Error("Not authenticated");
     const user = await ctx.db
       .query("users")
-      .withIndex("byTokenIdentifier", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
+      .withIndex("byTokenIdentifier", (q) =>
+        q.eq("tokenIdentifier", identity.tokenIdentifier),
+      )
       .unique();
     if (!user) throw new Error("User not found");
     return user.appUserId;
@@ -153,7 +186,8 @@ new RevenueCat(components.revenuecat, {
 });
 ```
 
-If you want tier-specific queries (e.g., `checkPremium`), write them on top of the helpers below. `revenuecat.api()` is the safe default, not the only path.
+If you want tier-specific queries (e.g., `checkPremium`), write them on top of
+the helpers below. `revenuecat.api()` is the safe default, not the only path.
 
 ### Check entitlements
 
@@ -177,7 +211,9 @@ export const checkPremium = query({
 
 ### Sync from REST API
 
-Webhooks can be delayed or dropped. `syncSubscriber` pulls a subscriber's current state from RevenueCat's API and reconciles it with the database. All writes are idempotent, no duplicates.
+Webhooks can be delayed or dropped. `syncSubscriber` pulls a subscriber's
+current state from RevenueCat's API and reconciles it with the database. All
+writes are idempotent, no duplicates.
 
 ```typescript
 import { action } from "./_generated/server";
@@ -191,7 +227,9 @@ export const syncCurrentUser = action({
     const appUserId = identity.subject;
     const res = await fetch(
       `https://api.revenuecat.com/v1/subscribers/${encodeURIComponent(appUserId)}`,
-      { headers: { Authorization: `Bearer ${process.env.REVENUECAT_API_KEY}` } },
+      {
+        headers: { Authorization: `Bearer ${process.env.REVENUECAT_API_KEY}` },
+      },
     );
     if (!res.ok) throw new Error(`RevenueCat API: ${res.status}`);
     const data = await res.json();
@@ -205,98 +243,131 @@ export const syncCurrentUser = action({
 
 Call on app foreground, after purchases, or on a schedule.
 
-> [!WARNING]
-> This requires a **secret** API key, not the public SDK key you pass to `Purchases.configure`. Set it as `REVENUECAT_API_KEY` in your Convex environment. Using the public key will fail at runtime or grant the wrong permissions.
+> [!WARNING] This requires a **secret** API key, not the public SDK key you pass
+> to `Purchases.configure`. Set it as `REVENUECAT_API_KEY` in your Convex
+> environment. Using the public key will fail at runtime or grant the wrong
+> permissions.
 
 ## API
 
-All query methods return empty arrays or `null` for missing users (never throw). Lifetime purchases without `expirationAtMs` are always considered active.
+All query methods return empty arrays or `null` for missing users (never throw).
+Lifetime purchases without `expirationAtMs` are always considered active.
 
-| Method | Returns |
-|:-------|:--------|
-| `hasEntitlement(ctx, { appUserId, entitlementId })` | `boolean` |
-| `getEntitlement(ctx, { appUserId, entitlementId })` | `Entitlement \| null` |
-| `getActiveEntitlements(ctx, { appUserId })` | `Entitlement[]` |
-| `getAllEntitlements(ctx, { appUserId })` | `Entitlement[]` |
-| `hasAnyEntitlement(ctx, { appUserId })` | `boolean` |
-| `getActiveSubscriptions(ctx, { appUserId })` | `Subscription[]` |
-| `getConsumables(ctx, { appUserId })` | `Subscription[]` |
-| `getAllSubscriptions(ctx, { appUserId })` | `Subscription[]` |
-| `getLatestSubscription(ctx, { appUserId })` | `Subscription \| null` |
-| `isSubscriber(ctx, { appUserId })` | `boolean` |
-| `isInTrial(ctx, { appUserId })` | `boolean` |
-| `wasInTrialEver(ctx, { appUserId })` | `boolean` |
-| `getRenewsAtMs(ctx, { appUserId, entitlementId })` | `number \| null` |
-| `getExpiresAtMs(ctx, { appUserId, entitlementId })` | `number \| null` |
-| `isInGracePeriod(ctx, { originalTransactionId })` | `GracePeriodStatus` |
-| `getSubscriptionsInGracePeriod(ctx, { appUserId })` | `Subscription[]` |
-| `getCustomer(ctx, { appUserId })` | `Customer \| null` |
-| `deleteCustomer(ctx, { appUserId })` | `DeleteCustomerResult` |
-| `getExperiment(ctx, { appUserId, experimentId })` | `Experiment \| null` |
-| `getExperiments(ctx, { appUserId })` | `Experiment[]` |
-| `getTransfer(ctx, { eventId })` | `Transfer \| null` |
-| `getTransfers(ctx, { limit? })` | `Transfer[]` |
-| `getInvoice(ctx, { invoiceId })` | `Invoice \| null` |
-| `getInvoices(ctx, { appUserId })` | `Invoice[]` |
-| `getVirtualCurrencyBalance(ctx, { appUserId, currencyCode })` | `VirtualCurrencyBalance \| null` |
-| `getVirtualCurrencyBalances(ctx, { appUserId })` | `VirtualCurrencyBalance[]` |
-| `getVirtualCurrencyTransactions(ctx, { appUserId, currencyCode? })` | `VirtualCurrencyTransaction[]` |
-| `syncSubscriber(ctx, { appUserId, subscriber })` | `SyncResult` |
-| `api()` | typed map of identity-aware queries |
-| `registerRoutes(http, { path? })` | mounts the webhook handler |
+| Method                                                              | Returns                             |
+| :------------------------------------------------------------------ | :---------------------------------- |
+| `hasEntitlement(ctx, { appUserId, entitlementId })`                 | `boolean`                           |
+| `getEntitlement(ctx, { appUserId, entitlementId })`                 | `Entitlement \| null`               |
+| `getActiveEntitlements(ctx, { appUserId })`                         | `Entitlement[]`                     |
+| `getAllEntitlements(ctx, { appUserId })`                            | `Entitlement[]`                     |
+| `hasAnyEntitlement(ctx, { appUserId })`                             | `boolean`                           |
+| `getActiveSubscriptions(ctx, { appUserId })`                        | `Subscription[]`                    |
+| `getConsumables(ctx, { appUserId })`                                | `Subscription[]`                    |
+| `getAllSubscriptions(ctx, { appUserId })`                           | `Subscription[]`                    |
+| `getLatestSubscription(ctx, { appUserId })`                         | `Subscription \| null`              |
+| `isSubscriber(ctx, { appUserId })`                                  | `boolean`                           |
+| `isInTrial(ctx, { appUserId })`                                     | `boolean`                           |
+| `wasInTrialEver(ctx, { appUserId })`                                | `boolean`                           |
+| `getRenewsAtMs(ctx, { appUserId, entitlementId })`                  | `number \| null`                    |
+| `getExpiresAtMs(ctx, { appUserId, entitlementId })`                 | `number \| null`                    |
+| `isInGracePeriod(ctx, { originalTransactionId })`                   | `GracePeriodStatus`                 |
+| `getSubscriptionsInGracePeriod(ctx, { appUserId })`                 | `Subscription[]`                    |
+| `getCustomer(ctx, { appUserId })`                                   | `Customer \| null`                  |
+| `deleteCustomer(ctx, { appUserId })`                                | `DeleteCustomerResult`              |
+| `getExperiment(ctx, { appUserId, experimentId })`                   | `Experiment \| null`                |
+| `getExperiments(ctx, { appUserId })`                                | `Experiment[]`                      |
+| `getTransfer(ctx, { eventId })`                                     | `Transfer \| null`                  |
+| `getTransfers(ctx, { limit? })`                                     | `Transfer[]`                        |
+| `getInvoice(ctx, { invoiceId })`                                    | `Invoice \| null`                   |
+| `getInvoices(ctx, { appUserId })`                                   | `Invoice[]`                         |
+| `getVirtualCurrencyBalance(ctx, { appUserId, currencyCode })`       | `VirtualCurrencyBalance \| null`    |
+| `getVirtualCurrencyBalances(ctx, { appUserId })`                    | `VirtualCurrencyBalance[]`          |
+| `getVirtualCurrencyTransactions(ctx, { appUserId, currencyCode? })` | `VirtualCurrencyTransaction[]`      |
+| `syncSubscriber(ctx, { appUserId, subscriber })`                    | `SyncResult`                        |
+| `api()`                                                             | typed map of identity-aware queries |
+| `registerRoutes(http, { path? })`                                   | mounts the webhook handler          |
 
 ### Helpers
 
-Standalone functions exported from `convex-revenuecat` for use on the client or in any query:
+Standalone functions exported from `convex-revenuecat` for use on the client or
+in any query:
 
-| Helper | Returns |
-|:-------|:--------|
-| `willRenew(sub)` | `boolean` |
+| Helper                              | Returns                          |
+| :---------------------------------- | :------------------------------- |
+| `willRenew(sub)`                    | `boolean`                        |
 | `decodeSubscriberAttributes(attrs)` | `Record<string, T> \| undefined` |
 
-`willRenew(sub)` re-derives the iOS `EntitlementInfo.willRenew` / Android `EntitlementInfoHelper.getWillRenew` signal from a `Subscription` doc (lifetime, `PREPAID`, `PROMOTIONAL`, `unsubscribeDetectedAt`, `billingIssueDetectedAt`). Matches the value already stored in `autoRenewStatus`. Useful when mixing stored state with live adjustments.
+`willRenew(sub)` re-derives the iOS `EntitlementInfo.willRenew` / Android
+`EntitlementInfoHelper.getWillRenew` signal from a `Subscription` doc (lifetime,
+`PREPAID`, `PROMOTIONAL`, `unsubscribeDetectedAt`, `billingIssueDetectedAt`).
+Matches the value already stored in `autoRenewStatus`. Useful when mixing stored
+state with live adjustments.
 
-`decodeSubscriberAttributes(attrs)` rewrites `__dollar__`-encoded keys back to RC-native `$`-prefixed names (`$email`, `$phoneNumber`, etc.). See [Decoding attribute keys](#decoding-attribute-keys).
+`decodeSubscriberAttributes(attrs)` rewrites `__dollar__`-encoded keys back to
+RC-native `$`-prefixed names (`$email`, `$phoneNumber`, etc.). See
+[Decoding attribute keys](#decoding-attribute-keys).
 
 ## Webhook Events
 
-RevenueCat emits 17 canonical event types. The component handles all of them plus two legacy events (`REFUND`, `SUBSCRIBER_ALIAS`) that older projects still receive:
+RevenueCat emits 17 canonical event types. The component handles all of them
+plus two legacy events (`REFUND`, `SUBSCRIBER_ALIAS`) that older projects still
+receive:
 
-| Event | What happens |
-|:------|:-------------|
-| `INITIAL_PURCHASE` | Creates subscription, grants entitlements |
-| `RENEWAL` | Extends expiration, clears stale billing/cancel state |
-| `CANCELLATION` | Keeps access until expiration. Refunds are the exception: revokes immediately when `cancel_reason === "CUSTOMER_SUPPORT"` OR `price < 0` (covers Google self-serve refunds and dashboard refunds where `cancel_reason` stays `DEVELOPER_INITIATED`) |
-| `EXPIRATION` | Revokes entitlements |
-| `BILLING_ISSUE` | Extends entitlement `expiresAtMs` to the grace period end so access continues during retry, and sets `autoRenewStatus: false` until `RENEWAL` resolves. If the issue resolves, `RENEWAL` extends further. If not, `EXPIRATION` fires at grace end and revokes. Even if `EXPIRATION` is dropped, access stops at grace end as a hard ceiling |
-| `SUBSCRIPTION_PAUSED` | Does not revoke |
-| `SUBSCRIPTION_EXTENDED` | Extends expiration |
-| `TRANSFER` | Moves entitlements and subscriptions between users. When the source is a `$RCAnonymousID:` ID with no active data remaining, the source customer row and its audit trail are dropped, matching the "anonymous ID is dead after merge" semantic that iOS `DeviceCache.clearCaches` and Android `deviceCache.clearCachesForAppUserID` apply client-side |
-| `UNCANCELLATION` | Clears cancellation status |
-| `PRODUCT_CHANGE` | Updates product on subscription |
-| `NON_RENEWING_PURCHASE` | Grants entitlements for one-time purchase. Stored with `kind: "consumable"` so `getActiveSubscriptions` filters them out and `getConsumables` returns them |
-| `TEMPORARY_ENTITLEMENT_GRANT` | Temp access during store outage (24h max) |
-| `REFUND_REVERSED` | Restores entitlements |
-| `TEST` | Logged only |
-| `INVOICE_ISSUANCE` | Invoice created (Web Billing) |
-| `VIRTUAL_CURRENCY_TRANSACTION` | Currency adjustment |
-| `EXPERIMENT_ENROLLMENT` | A/B test enrollment tracked |
-| `REFUND` *(legacy)* | Revokes entitlements. As of 2026 RC emits refunds as `CANCELLATION` with `cancel_reason: "CUSTOMER_SUPPORT"`. Handler retained for legacy projects |
-| `SUBSCRIBER_ALIAS` *(legacy)* | Migrates data from anonymous to real user ID when `logIn()` is called on a previously-anonymous user. Drops the anonymous source customer row after merge. [Deprecated](https://community.revenuecat.com/sdks-51/replacement-for-subscriber-alias-event-in-webhook-1291). New projects get `TRANSFER` instead (note: `TRANSFER` also fires when `restorePurchases()` attaches an existing receipt to a new user, which is semantically different from alias) |
+| Event                          | What happens                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `INITIAL_PURCHASE`             | Creates subscription, grants entitlements                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `RENEWAL`                      | Extends expiration, clears stale billing/cancel state                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `CANCELLATION`                 | Keeps access until expiration. Refunds are the exception: revokes immediately when `cancel_reason === "CUSTOMER_SUPPORT"` OR `price < 0` (covers Google self-serve refunds and dashboard refunds where `cancel_reason` stays `DEVELOPER_INITIATED`)                                                                                                                                                                                                          |
+| `EXPIRATION`                   | Revokes entitlements                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `BILLING_ISSUE`                | Extends entitlement `expiresAtMs` to the grace period end so access continues during retry, and sets `autoRenewStatus: false` until `RENEWAL` resolves. If the issue resolves, `RENEWAL` extends further. If not, `EXPIRATION` fires at grace end and revokes. Even if `EXPIRATION` is dropped, access stops at grace end as a hard ceiling                                                                                                                  |
+| `SUBSCRIPTION_PAUSED`          | Does not revoke                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `SUBSCRIPTION_EXTENDED`        | Extends expiration                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `TRANSFER`                     | Moves entitlements and subscriptions between users. When the source is a `$RCAnonymousID:` ID with no active data remaining, the source customer row and its audit trail are dropped, matching the "anonymous ID is dead after merge" semantic that iOS `DeviceCache.clearCaches` and Android `deviceCache.clearCachesForAppUserID` apply client-side                                                                                                        |
+| `UNCANCELLATION`               | Clears cancellation status                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `PRODUCT_CHANGE`               | Updates product on subscription                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `NON_RENEWING_PURCHASE`        | Grants entitlements for one-time purchase. Stored with `kind: "consumable"` so `getActiveSubscriptions` filters them out and `getConsumables` returns them                                                                                                                                                                                                                                                                                                   |
+| `TEMPORARY_ENTITLEMENT_GRANT`  | Temp access during store outage (24h max)                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `REFUND_REVERSED`              | Restores entitlements                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `TEST`                         | Logged only                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `INVOICE_ISSUANCE`             | Invoice created (Web Billing)                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `VIRTUAL_CURRENCY_TRANSACTION` | Currency adjustment                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `EXPERIMENT_ENROLLMENT`        | A/B test enrollment tracked                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `REFUND` _(legacy)_            | Revokes entitlements. As of 2026 RC emits refunds as `CANCELLATION` with `cancel_reason: "CUSTOMER_SUPPORT"`. Handler retained for legacy projects                                                                                                                                                                                                                                                                                                           |
+| `SUBSCRIBER_ALIAS` _(legacy)_  | Migrates data from anonymous to real user ID when `logIn()` is called on a previously-anonymous user. Drops the anonymous source customer row after merge. [Deprecated](https://community.revenuecat.com/sdks-51/replacement-for-subscriber-alias-event-in-webhook-1291). New projects get `TRANSFER` instead (note: `TRANSFER` also fires when `restorePurchases()` attaches an existing receipt to a new user, which is semantically different from alias) |
 
-`CANCELLATION` does NOT revoke entitlements for normal unsubscribes. Users keep access until `EXPIRATION`. Refunds are the exception: a `CANCELLATION` where `cancel_reason === "CUSTOMER_SUPPORT"` OR `price < 0` revokes entitlements immediately. `price < 0` catches Google Play self-serve refunds and dashboard-issued refunds that leave `cancel_reason` as `DEVELOPER_INITIATED`. Gating on `cancel_reason` alone leaks access in those cases.
+`CANCELLATION` does NOT revoke entitlements for normal unsubscribes. Users keep
+access until `EXPIRATION`. Refunds are the exception: a `CANCELLATION` where
+`cancel_reason === "CUSTOMER_SUPPORT"` OR `price < 0` revokes entitlements
+immediately. `price < 0` catches Google Play self-serve refunds and
+dashboard-issued refunds that leave `cancel_reason` as `DEVELOPER_INITIATED`.
+Gating on `cancel_reason` alone leaks access in those cases.
 
-A refund doesn't necessarily deactivate auto-renewal: if the subscription auto-renews to a new period, a subsequent `RENEWAL` restores access. For extra safety on cancellation events, callers can optionally call `syncSubscriber` to cross-check against `GET /v1/subscribers/{app_user_id}`.
+A refund doesn't necessarily deactivate auto-renewal: if the subscription
+auto-renews to a new period, a subsequent `RENEWAL` restores access. For extra
+safety on cancellation events, callers can optionally call `syncSubscriber` to
+cross-check against `GET /v1/subscribers/{app_user_id}`.
 
 ### Access-check semantics
 
-`hasEntitlement` mirrors the iOS SDK's `EntitlementInfo.isActive`: pure `expiresAtMs > now` (with lifetime entitlements as the no-expiry case). Grace period is encoded into `expiresAtMs` by the `BILLING_ISSUE` handler and `syncSubscriber`, not signaled via a separate flag. This avoids the "indefinite access if EXPIRATION drops" bug where a `billingIssueDetectedAt` short-circuit would keep entitlements active forever after a failed grace period without retry.
+`hasEntitlement` mirrors the iOS SDK's `EntitlementInfo.isActive`: pure
+`expiresAtMs > now` (with lifetime entitlements as the no-expiry case). Grace
+period is encoded into `expiresAtMs` by the `BILLING_ISSUE` handler and
+`syncSubscriber`, not signaled via a separate flag. This avoids the "indefinite
+access if EXPIRATION drops" bug where a `billingIssueDetectedAt` short-circuit
+would keep entitlements active forever after a failed grace period without
+retry.
 
 ### Derived `willRenew`
 
-`Subscription.autoRenewStatus` is the iOS `EntitlementInfo.willRenew` / Android `EntitlementInfoHelper.getWillRenew` signal, **not** the raw user-preference toggle. It's `false` whenever any of these hold: lifetime entitlement (no `expirationAtMs`), `periodType === "PREPAID"`, `store === "PROMOTIONAL"`, `unsubscribeDetectedAt` set, or `billingIssueDetectedAt` set. Webhook and REST sync paths both compute it from the same five-signal check so stored values converge.
+`Subscription.autoRenewStatus` is the iOS `EntitlementInfo.willRenew` / Android
+`EntitlementInfoHelper.getWillRenew` signal, **not** the raw user-preference
+toggle. It's `false` whenever any of these hold: lifetime entitlement (no
+`expirationAtMs`), `periodType === "PREPAID"`, `store === "PROMOTIONAL"`,
+`unsubscribeDetectedAt` set, or `billingIssueDetectedAt` set. Webhook and REST
+sync paths both compute it from the same five-signal check so stored values
+converge.
 
-Consumers reading `Subscription` docs can re-derive on the client with the `willRenew` helper:
+Consumers reading `Subscription` docs can re-derive on the client with the
+`willRenew` helper:
 
 ```typescript
 import { willRenew } from "convex-revenuecat";
@@ -306,11 +377,19 @@ const active = subs.filter(willRenew);
 
 ### Customer record
 
-`getCustomer` returns `countryCode` (ISO 3166-1 alpha-2, mirrored from the latest event that carried one) and `managementUrl` (RC REST `subscriber.management_url`, the deep link to the native subscription manager: App Store on iOS, Play Store on Android, Stripe portal on web). `managementUrl` is populated only by `syncSubscriber`. Webhooks don't carry it. Both are `undefined` until the first event/sync that supplies them.
+`getCustomer` returns `countryCode` (ISO 3166-1 alpha-2, mirrored from the
+latest event that carried one) and `managementUrl` (RC REST
+`subscriber.management_url`, the deep link to the native subscription manager:
+App Store on iOS, Play Store on Android, Stripe portal on web). `managementUrl`
+is populated only by `syncSubscriber`. Webhooks don't carry it. Both are
+`undefined` until the first event/sync that supplies them.
 
 ### Family sharing
 
-`entitlements.ownershipType` is populated from the webhook `ownership_type` field (`PURCHASED` or `FAMILY_SHARED`) on every grant/extend, and from REST sync. Consumers that want to exclude family-shared access for single-seat products can filter:
+`entitlements.ownershipType` is populated from the webhook `ownership_type`
+field (`PURCHASED` or `FAMILY_SHARED`) on every grant/extend, and from REST
+sync. Consumers that want to exclude family-shared access for single-seat
+products can filter:
 
 ```typescript
 const active = await revenuecat.getActiveEntitlements(ctx, { appUserId });
@@ -319,7 +398,11 @@ const paidAccess = active.filter((e) => e.ownershipType !== "FAMILY_SHARED");
 
 ## Lifecycle hooks
 
-Register mutations or actions that fire when an entitlement transitions or a customer is deleted. Every hook is optional. Scheduling happens inside the component mutation that made the change, so hooks are atomic with state writes: a rolled-back mutation never fires its hooks, and retries of the same webhook (same `event.id`) don't double-fire.
+Register mutations or actions that fire when an entitlement transitions or a
+customer is deleted. Every hook is optional. Scheduling happens inside the
+component mutation that made the change, so hooks are atomic with state writes:
+a rolled-back mutation never fires its hooks, and retries of the same webhook
+(same `event.id`) don't double-fire.
 
 ```typescript
 // convex/revenuecat.ts
@@ -389,56 +472,96 @@ export const onDeleted = internalMutation({
 
 Firing rules:
 
-- `onEntitlementActivated` fires when an entitlement moves from not-active to active for an `appUserId`. Triggers include `INITIAL_PURCHASE`, `RENEWAL` restoring after revoke, `REFUND_REVERSED`, `TRANSFER` onto a user, `SUBSCRIBER_ALIAS`, and `syncSubscriber` catching a change the webhook missed.
-- `onEntitlementDeactivated` fires when an active entitlement transitions to not-active. Covers `EXPIRATION`, refund `CANCELLATION` (`cancel_reason: "CUSTOMER_SUPPORT"` or `price < 0`), `TRANSFER` off a user, and sync reconciliation.
-- `onCustomerDeleted` fires after `deleteCustomer` purges the component-local rows for an `appUserId`.
+- `onEntitlementActivated` fires when an entitlement moves from not-active to
+  active for an `appUserId`. Triggers include `INITIAL_PURCHASE`, `RENEWAL`
+  restoring after revoke, `REFUND_REVERSED`, `TRANSFER` onto a user,
+  `SUBSCRIBER_ALIAS`, and `syncSubscriber` catching a change the webhook missed.
+- `onEntitlementDeactivated` fires when an active entitlement transitions to
+  not-active. Covers `EXPIRATION`, refund `CANCELLATION`
+  (`cancel_reason: "CUSTOMER_SUPPORT"` or `price < 0`), `TRANSFER` off a user,
+  and sync reconciliation.
+- `onCustomerDeleted` fires after `deleteCustomer` purges the component-local
+  rows for an `appUserId`.
 
-Hook arguments include `sourceEventType` (the RC webhook `event.type` that caused the transition, or `"SYNC"` when detected by `syncSubscriber`) plus the entitlement's `productId`, `purchasedAtMs`, `expiresAtMs`, `store`, `ownershipType`, and `isSandbox`. `onEntitlementDeactivated` reports the entitlement's state **before** deactivation so consumers can log, attribute, or notify with the lost product.
+Hook arguments include `sourceEventType` (the RC webhook `event.type` that
+caused the transition, or `"SYNC"` when detected by `syncSubscriber`) plus the
+entitlement's `productId`, `purchasedAtMs`, `expiresAtMs`, `store`,
+`ownershipType`, and `isSandbox`. `onEntitlementDeactivated` reports the
+entitlement's state **before** deactivation so consumers can log, attribute, or
+notify with the lost product.
 
 Per-event semantics:
 
-- Multi-entitlement events fire one hook invocation per transitioning entitlement.
-- Idempotent events fire at most once per transition. A retry with the same `event.id` dedups before the handler runs.
-- `TRANSFER` fires `onEntitlementDeactivated` for the source user and `onEntitlementActivated` for the destination.
-- Hooks run via Convex's scheduler **after** the enclosing mutation commits. A rolled-back mutation never schedules its hooks (scheduler writes are part of the transaction). A hook throwing does NOT retry the webhook. Scheduled mutations retry exactly-once per Convex scheduler policy. Scheduled actions retry at-most-once. Make hooks idempotent.
-- Snapshots that power transition detection only run when at least one hook is configured, so consumers without hooks pay zero overhead.
+- Multi-entitlement events fire one hook invocation per transitioning
+  entitlement.
+- Idempotent events fire at most once per transition. A retry with the same
+  `event.id` dedups before the handler runs.
+- `TRANSFER` fires `onEntitlementDeactivated` for the source user and
+  `onEntitlementActivated` for the destination.
+- Hooks run via Convex's scheduler **after** the enclosing mutation commits. A
+  rolled-back mutation never schedules its hooks (scheduler writes are part of
+  the transaction). A hook throwing does NOT retry the webhook. Scheduled
+  mutations retry exactly-once per Convex scheduler policy. Scheduled actions
+  retry at-most-once. Make hooks idempotent.
+- Snapshots that power transition detection only run when at least one hook is
+  configured, so consumers without hooks pay zero overhead.
 
 ### Cross-platform coverage
 
-Handlers accept webhook payloads from all RevenueCat stores: Apple App Store, Mac App Store, Google Play Store, Amazon Appstore, Stripe, Paddle, Roku, Samsung Galaxy Store, RevenueCat Web Billing, the External Purchases API, and promotional/test grants. `store` values unknown to a given schema version normalize to `UNKNOWN_STORE` rather than rejecting the event. Payload fields not present in the component's validator are accepted and stored in `webhookEvents.payload` (RC reserves the right to add fields without versioning).
+Handlers accept webhook payloads from all RevenueCat stores: Apple App Store,
+Mac App Store, Google Play Store, Amazon Appstore, Stripe, Paddle, Roku, Samsung
+Galaxy Store, RevenueCat Web Billing, the External Purchases API, and
+promotional/test grants. `store` values unknown to a given schema version
+normalize to `UNKNOWN_STORE` rather than rejecting the event. Payload fields not
+present in the component's validator are accepted and stored in
+`webhookEvents.payload` (RC reserves the right to add fields without
+versioning).
 
 ## Delivery and retries
 
-RevenueCat delivers webhooks at-least-once with rare duplicates. The component dedupes by `event.id` via the `webhookEvents` table.
+RevenueCat delivers webhooks at-least-once with rare duplicates. The component
+dedupes by `event.id` via the `webhookEvents` table.
 
-RC's retry policy: 5 retries at 5, 10, 20, 40, and 80 minutes after first failure. Request timeout is 60s. Only HTTP 200 counts as success. Any other code (including 429 from the built-in rate limiter) triggers retry. After 5 failed attempts the event is dropped.
+RC's retry policy: 5 retries at 5, 10, 20, 40, and 80 minutes after first
+failure. Request timeout is 60s. Only HTTP 200 counts as success. Any other code
+(including 429 from the built-in rate limiter) triggers retry. After 5 failed
+attempts the event is dropped.
 
 ## Authentication
 
-> [!IMPORTANT]
-> RevenueCat does not sign webhook payloads. There's no HMAC and no `X-RevenueCat-Signature` header. The only auth mechanism is the dashboard-configured `Authorization` header shared secret. Rotate it from the RC dashboard if you suspect leakage.
+> [!IMPORTANT] RevenueCat does not sign webhook payloads. There's no HMAC and no
+> `X-RevenueCat-Signature` header. The only auth mechanism is the
+> dashboard-configured `Authorization` header shared secret. Rotate it from the
+> RC dashboard if you suspect leakage.
 
 ## RevenueCat REST API rate limits
 
-If you call `syncSubscriber` or the RC REST API from your actions, RC applies these limits:
+If you call `syncSubscriber` or the RC REST API from your actions, RC applies
+these limits:
 
-| API | Domain | Limit |
-|:----|:-------|:------|
-| v1 `/v1/subscribers/...` | (undocumented) | Treat as unpublished. Throttle aggressively |
-| v2 Customer Information | Customer Information | 480 req/min |
-| v2 Project Configuration | Project Configuration | 60 req/min |
-| v2 Charts & Metrics | Charts & Metrics | 5 req/min |
-| v2 Virtual Currencies - Create Transaction | Virtual Currencies - Create Transaction | 480 req/min |
+| API                                        | Domain                                  | Limit                                       |
+| :----------------------------------------- | :-------------------------------------- | :------------------------------------------ |
+| v1 `/v1/subscribers/...`                   | (undocumented)                          | Treat as unpublished. Throttle aggressively |
+| v2 Customer Information                    | Customer Information                    | 480 req/min                                 |
+| v2 Project Configuration                   | Project Configuration                   | 60 req/min                                  |
+| v2 Charts & Metrics                        | Charts & Metrics                        | 5 req/min                                   |
+| v2 Virtual Currencies - Create Transaction | Virtual Currencies - Create Transaction | 480 req/min                                 |
 
-Limits apply per API key (app-level keys) or per developer (developer-level keys). Responses carry `RevenueCat-Rate-Limit-Current-Usage` and `RevenueCat-Rate-Limit-Current-Limit` headers. 429 on exceed.
+Limits apply per API key (app-level keys) or per developer (developer-level
+keys). Responses carry `RevenueCat-Rate-Limit-Current-Usage` and
+`RevenueCat-Rate-Limit-Current-Limit` headers. 429 on exceed.
 
 ## PII and subscriber attributes
 
-Webhooks carry subscriber attributes with RC-reserved `$`-prefixed keys (`$email`, `$phoneNumber`, `$apnsTokens`, `$fcmTokens`, `$displayName`, `$ip`, etc.).
+Webhooks carry subscriber attributes with RC-reserved `$`-prefixed keys
+(`$email`, `$phoneNumber`, `$apnsTokens`, `$fcmTokens`, `$displayName`, `$ip`,
+etc.).
 
 ### Audit-log redaction
 
-The `webhookEvents` audit table keeps 30 days of payloads for debugging. The default `redactPayload` strips the reserved PII keys from `subscriber_attributes` before writing to that table. Override or disable:
+The `webhookEvents` audit table keeps 30 days of payloads for debugging. The
+default `redactPayload` strips the reserved PII keys from
+`subscriber_attributes` before writing to that table. Override or disable:
 
 ```typescript
 new RevenueCat(components.revenuecat, {
@@ -454,7 +577,8 @@ new RevenueCat(components.revenuecat, {
 
 ### Decoding attribute keys
 
-Customer attributes are stored with `__dollar__`-encoded keys. Convex rejects `$` at every nesting level, so the component encodes on write. Decode on read:
+Customer attributes are stored with `__dollar__`-encoded keys. Convex rejects
+`$` at every nesting level, so the component encodes on write. Decode on read:
 
 ```typescript
 import { decodeSubscriberAttributes } from "convex-revenuecat";
@@ -466,20 +590,46 @@ console.log(attrs?.$email?.value); // "user@example.com"
 
 ## Limitations
 
-- No automatic backfill. Existing subscribers before webhook setup won't appear until they trigger a new event or you call `syncSubscriber` for each user.
+- No automatic backfill. Existing subscribers before webhook setup won't appear
+  until they trigger a new event or you call `syncSubscriber` for each user.
 - Raw payloads stored for 30 days. PII keys redacted by default (see above).
-- Rate limited at 100 req/min per app. Dedup runs BEFORE the rate-limit check so webhook replays (same `event.id`) don't consume the rate budget.
-- Transfer/alias/purge operations cap at 500 records per user to stay under Convex's per-transaction write budget. Pathological accounts (more than 500 entitlements or subscriptions for a single user) will throw instead of silently corrupting state.
-- `event.id` is capped at 128 bytes. Webhook bodies are capped at 1MB. Both reject at the HTTP boundary before any database touch.
-- `event.event_timestamp_ms` is clamped to `now + 5min` on insert so a clock-skewed or malicious timestamp can't lock `customers.firstSeenAt` / `lastSeenAt` at a far-future value.
+- Rate limited at 100 req/min per app. Dedup runs BEFORE the rate-limit check so
+  webhook replays (same `event.id`) don't consume the rate budget.
+- Transfer/alias/purge operations cap at 500 records per user to stay under
+  Convex's per-transaction write budget. Pathological accounts (more than 500
+  entitlements or subscriptions for a single user) will throw instead of
+  silently corrupting state.
+- `event.id` is capped at 128 bytes. Webhook bodies are capped at 1MB. Both
+  reject at the HTTP boundary before any database touch.
+- `event.event_timestamp_ms` is clamped to `now + 5min` on insert so a
+  clock-skewed or malicious timestamp can't lock `customers.firstSeenAt` /
+  `lastSeenAt` at a far-future value.
+
+## Maintenance
+
+No setup required. The component prunes its own bookkeeping tables on internal
+cron jobs:
+
+- rate-limit rows older than the 60s window, hourly
+- webhook audit events past the 30-day retention, daily
+
+Both delete in batches and self-reschedule if a backlog exceeds the per-run cap.
 
 ## Upgrading from 0.2.1
 
-If your deployment shipped 0.2.1 or earlier, run two one-shot migrations after upgrading. Both are idempotent and paginated. Loop until `nextCursor` is null.
+If your deployment shipped 0.2.1 or earlier, run two one-shot migrations after
+upgrading. Both are idempotent and paginated. Loop until `nextCursor` is null.
 
-`transfers.backfillTransferParticipants` populates the new `transferParticipants` join table for legacy `transfers` rows so GDPR purge stays index-driven instead of falling back to the bounded scan.
+`transfers.backfillTransferParticipants` populates the new
+`transferParticipants` join table for legacy `transfers` rows so GDPR purge
+stays index-driven instead of falling back to the bounded scan.
 
-`subscriptions.backfillKind` walks the `webhookEvents` audit log for `NON_RENEWING_PURCHASE` events and patches matching subscriptions to `kind: "consumable"`. Without this, pre-0.3.0 consumable rows leak into `getActiveSubscriptions` (their `kind` is `undefined`, so the filter treats them as recurring). Bounded by the 30-day audit retention. Older rows can't be classified this way and stay `kind: undefined`.
+`subscriptions.backfillKind` walks the `webhookEvents` audit log for
+`NON_RENEWING_PURCHASE` events and patches matching subscriptions to
+`kind: "consumable"`. Without this, pre-0.3.0 consumable rows leak into
+`getActiveSubscriptions` (their `kind` is `undefined`, so the filter treats them
+as recurring). Bounded by the 30-day audit retention. Older rows can't be
+classified this way and stay `kind: undefined`.
 
 ```typescript
 import { internalAction } from "./_generated/server";
@@ -506,9 +656,16 @@ export const backfillRevenueCat = internalAction({
 
 ## GDPR / data deletion
 
-`deleteCustomer(ctx, { appUserId })` purges all component-local rows for a user: customer, subscriptions, entitlements, experiments, invoices, virtual currency balances/transactions, webhook events, and transfers. Call from a mutation or action.
+`deleteCustomer(ctx, { appUserId })` purges all component-local rows for a user:
+customer, subscriptions, entitlements, experiments, invoices, virtual currency
+balances/transactions, webhook events (including the `TRANSFER` audit rows,
+which carry no `app_user_id` and are matched through the user's transfer
+records), and transfers. Audit rows recorded under a prior alias ID age out via
+the 30-day retention. Call from a mutation or action.
 
-To also purge RevenueCat-side, call `DELETE /v1/subscribers/{app_user_id}` from a Convex action with a secret API key. RC confirms the delete endpoint is sufficient for GDPR erasure on their side.
+To also purge RevenueCat-side, call `DELETE /v1/subscribers/{app_user_id}` from
+a Convex action with a secret API key. RC confirms the delete endpoint is
+sufficient for GDPR erasure on their side.
 
 ```typescript
 import { action } from "./_generated/server";
@@ -523,18 +680,28 @@ export const forgetMe = action({
     const local = await revenuecat.deleteCustomer(ctx, { appUserId });
     await fetch(
       `https://api.revenuecat.com/v1/subscribers/${encodeURIComponent(appUserId)}`,
-      { method: "DELETE", headers: { Authorization: `Bearer ${process.env.REVENUECAT_API_KEY}` } },
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${process.env.REVENUECAT_API_KEY}` },
+      },
     );
     return local;
   },
 });
 ```
 
-GDPR data deletion requests typically arrive through a support workflow rather than a self-serve client mutation. If you wire a public action like the one above, keep it scoped to the authenticated caller's own data. For admin-initiated purges (a support agent acting on a different `appUserId`), use a separate `internalAction` gated by an explicit role check, never a public action that accepts `appUserId` from the client.
+GDPR data deletion requests typically arrive through a support workflow rather
+than a self-serve client mutation. If you wire a public action like the one
+above, keep it scoped to the authenticated caller's own data. For
+admin-initiated purges (a support agent acting on a different `appUserId`), use
+a separate `internalAction` gated by an explicit role check, never a public
+action that accepts `appUserId` from the client.
 
 ## Testing
 
-The `convex-revenuecat/test` export wires the component into a `convex-test` instance so you can exercise webhooks and entitlement queries in unit tests without a live deployment:
+The `convex-revenuecat/test` export wires the component into a `convex-test`
+instance so you can exercise webhooks and entitlement queries in unit tests
+without a live deployment:
 
 ```typescript
 import { convexTest } from "convex-test";
@@ -548,7 +715,8 @@ export function initConvexTest() {
 }
 ```
 
-Run your suite with whatever test runner `convex-test` supports (Vitest, by default):
+Run your suite with whatever test runner `convex-test` supports (Vitest, by
+default):
 
 ```bash
 npm test
@@ -556,7 +724,10 @@ npm test
 
 ## ID Matching
 
-The `app_user_id` you pass to `Purchases.logIn()` must match what you query with `hasEntitlement()`. Use a consistent identifier like your Convex user ID. The `entitlementId` must match exactly what you configured in the RevenueCat dashboard.
+The `app_user_id` you pass to `Purchases.logIn()` must match what you query with
+`hasEntitlement()`. Use a consistent identifier like your Convex user ID. The
+`entitlementId` must match exactly what you configured in the RevenueCat
+dashboard.
 
 ## Contributing
 
@@ -564,7 +735,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Security
 
-Do not report vulnerabilities through public issues. See [SECURITY.md](SECURITY.md) for the policy, private reporting channels, and coordinated disclosure timeline.
+Do not report vulnerabilities through public issues. See
+[SECURITY.md](SECURITY.md) for the policy, private reporting channels, and
+coordinated disclosure timeline.
 
 ## Changelog
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,7 +18,11 @@ export default [
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: ["./tsconfig.json", "./example/convex/tsconfig.json"],
+        project: [
+          "./tsconfig.json",
+          "./example/convex/tsconfig.json",
+          "./example/tsconfig.app.json",
+        ],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/example/.env.example
+++ b/example/.env.example
@@ -2,3 +2,8 @@
 # Set this in RevenueCat Dashboard → Integrations → Webhooks → Authorization header
 # Then add to Convex: npx convex env set REVENUECAT_WEBHOOK_AUTH "your-secret-value"
 REVENUECAT_WEBHOOK_AUTH=
+
+# --- Example frontend (npm run example, read by Vite) ---
+# Publishable client values; copy to example/.env.local with your own.
+VITE_CONVEX_URL=https://your-deployment.convex.cloud
+VITE_REVENUECAT_API_KEY=your_revenuecat_test_store_key

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as demo from "../demo.js";
 import type * as http from "../http.js";
+import type * as simulate from "../simulate.js";
 import type * as subscriptions from "../subscriptions.js";
 
 import type {
@@ -21,6 +22,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   demo: typeof demo;
   http: typeof http;
+  simulate: typeof simulate;
   subscriptions: typeof subscriptions;
 }>;
 

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -8,12 +8,18 @@
  * @module
  */
 
+import type * as demo from "../demo.js";
 import type * as http from "../http.js";
 import type * as subscriptions from "../subscriptions.js";
 
-import type { ApiFromModules, FilterApi, FunctionReference } from "convex/server";
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  demo: typeof demo;
   http: typeof http;
   subscriptions: typeof subscriptions;
 }>;
@@ -26,7 +32,10 @@ declare const fullApi: ApiFromModules<{
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-export declare const api: FilterApi<typeof fullApi, FunctionReference<any, "public">>;
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
 
 /**
  * A utility for referencing Convex functions in your app's internal API.
@@ -36,7 +45,10 @@ export declare const api: FilterApi<typeof fullApi, FunctionReference<any, "publ
  * const myFunctionReference = internal.myModule.myFunction;
  * ```
  */
-export declare const internal: FilterApi<typeof fullApi, FunctionReference<any, "internal">>;
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
 
 export declare const components: {
   revenuecat: import("convex-revenuecat/_generated/component.js").ComponentApi<"revenuecat">;

--- a/example/convex/demo.ts
+++ b/example/convex/demo.ts
@@ -4,7 +4,7 @@
 // identity-aware `revenuecat.api()` in `subscriptions.ts` (see the README
 // "Authorize every query"). This file exists purely to drive the showcase UI.
 import { v } from "convex/values";
-import { query } from "./_generated/server.js";
+import { mutation, query } from "./_generated/server.js";
 import { components } from "./_generated/api.js";
 import { RevenueCat } from "convex-revenuecat";
 
@@ -57,5 +57,15 @@ export const recentEvents = query({
       appUserId,
       limit: 25,
     });
+  },
+});
+
+/** DEMO ONLY. Purge every component-local row for the user so the showcase can
+ * start from a clean slate. Same path as the GDPR delete; returns per-table
+ * counts. Never expose an appUserId-taking purge like this in real code. */
+export const reset = mutation({
+  args: { appUserId: v.string() },
+  handler: async (ctx, { appUserId }) => {
+    return await revenuecat.deleteCustomer(ctx, { appUserId });
   },
 });

--- a/example/convex/demo.ts
+++ b/example/convex/demo.ts
@@ -1,0 +1,61 @@
+// DEMO ONLY. These queries take an explicit `appUserId` so the example UI can
+// inspect any user the webhooks populate, without standing up auth. Production
+// code must NOT accept `appUserId` from the client, that's an IDOR. Use the
+// identity-aware `revenuecat.api()` in `subscriptions.ts` (see the README
+// "Authorize every query"). This file exists purely to drive the showcase UI.
+import { v } from "convex/values";
+import { query } from "./_generated/server.js";
+import { components } from "./_generated/api.js";
+import { RevenueCat } from "convex-revenuecat";
+
+const revenuecat = new RevenueCat(components.revenuecat, {
+  REVENUECAT_WEBHOOK_AUTH: process.env.REVENUECAT_WEBHOOK_AUTH,
+});
+
+/** Everything the showcase panels render, in one reactive read. */
+export const status = query({
+  args: { appUserId: v.string() },
+  handler: async (ctx, { appUserId }) => {
+    const [
+      isSubscriber,
+      isInTrial,
+      customer,
+      activeEntitlements,
+      subscriptions,
+      gracePeriod,
+      virtualCurrency,
+      invoices,
+    ] = await Promise.all([
+      revenuecat.isSubscriber(ctx, { appUserId }),
+      revenuecat.isInTrial(ctx, { appUserId }),
+      revenuecat.getCustomer(ctx, { appUserId }),
+      revenuecat.getActiveEntitlements(ctx, { appUserId }),
+      revenuecat.getAllSubscriptions(ctx, { appUserId }),
+      revenuecat.getSubscriptionsInGracePeriod(ctx, { appUserId }),
+      revenuecat.getVirtualCurrencyBalances(ctx, { appUserId }),
+      revenuecat.getInvoices(ctx, { appUserId }),
+    ]);
+    return {
+      isSubscriber,
+      isInTrial,
+      customer,
+      activeEntitlements,
+      subscriptions,
+      gracePeriod,
+      virtualCurrency,
+      invoices,
+    };
+  },
+});
+
+/** Recent webhook events for the user, newest first, so the UI can show events
+ * landing live. (TRANSFER events carry no app_user_id and won't appear here.) */
+export const recentEvents = query({
+  args: { appUserId: v.string() },
+  handler: async (ctx, { appUserId }) => {
+    return await ctx.runQuery(components.revenuecat.webhookEvents.listByUser, {
+      appUserId,
+      limit: 25,
+    });
+  },
+});

--- a/example/convex/simulate.ts
+++ b/example/convex/simulate.ts
@@ -1,0 +1,248 @@
+// DEMO ONLY. Fires synthetic RevenueCat webhook events so the showcase UI can
+// exercise every event type the component handles and you can watch the live
+// state react. It calls the component's `process` directly (the same mutation
+// the auth-gated HTTP handler calls), so no secret is needed from the browser.
+// Production receives these from RevenueCat over the webhook; this is purely a
+// test harness for the example.
+import { v } from "convex/values";
+import { mutation } from "./_generated/server.js";
+import { components } from "./_generated/api.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+type Json = Record<string, unknown>;
+const rid = (p: string) =>
+  `sim-${p}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+// Build a realistic RC event payload for a named scenario. `original_transaction_id`
+// is stable per user so renew/cancel/expire act on the same subscription.
+function buildEvent(
+  appUserId: string,
+  scenario: string,
+  toAppUserId: string,
+): Json {
+  const now = Date.now();
+  const txn = `sim-txn-${appUserId}`;
+  const sub: Json = {
+    app_id: "app_demo",
+    app_user_id: appUserId,
+    original_app_user_id: appUserId,
+    aliases: [appUserId],
+    event_timestamp_ms: now,
+    environment: "PRODUCTION",
+    store: "APP_STORE",
+    product_id: "monthly",
+    entitlement_ids: ["TEST Pro"],
+    period_type: "NORMAL",
+    purchased_at_ms: now,
+    transaction_id: txn,
+    original_transaction_id: txn,
+    price: 9.99,
+    currency: "USD",
+  };
+  switch (scenario) {
+    case "INITIAL_PURCHASE":
+      return {
+        ...sub,
+        id: rid("init"),
+        type: "INITIAL_PURCHASE",
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "RENEWAL":
+      return {
+        ...sub,
+        id: rid("renew"),
+        type: "RENEWAL",
+        renewal_number: 2,
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "TRIAL":
+      return {
+        ...sub,
+        id: rid("trial"),
+        type: "INITIAL_PURCHASE",
+        period_type: "TRIAL",
+        price: 0,
+        expiration_at_ms: now + 7 * DAY,
+      };
+    case "PRODUCT_CHANGE":
+      return {
+        ...sub,
+        id: rid("change"),
+        type: "PRODUCT_CHANGE",
+        new_product_id: "yearly",
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "UNSUBSCRIBE":
+      return {
+        ...sub,
+        id: rid("unsub"),
+        type: "CANCELLATION",
+        cancel_reason: "UNSUBSCRIBE",
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "UNCANCELLATION":
+      return {
+        ...sub,
+        id: rid("uncancel"),
+        type: "UNCANCELLATION",
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "PAUSE":
+      return {
+        ...sub,
+        id: rid("pause"),
+        type: "SUBSCRIPTION_PAUSED",
+        auto_resume_at_ms: now + 14 * DAY,
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "EXTEND":
+      return {
+        ...sub,
+        id: rid("extend"),
+        type: "SUBSCRIPTION_EXTENDED",
+        expiration_at_ms: now + 37 * DAY,
+      };
+    case "BILLING_ISSUE":
+      return {
+        ...sub,
+        id: rid("billing"),
+        type: "BILLING_ISSUE",
+        grace_period_expiration_at_ms: now + 16 * DAY,
+        expiration_at_ms: now + DAY,
+      };
+    case "EXPIRATION":
+      return {
+        ...sub,
+        id: rid("expire"),
+        type: "EXPIRATION",
+        expiration_reason: "BILLING_ERROR",
+        expiration_at_ms: now - 1,
+      };
+    case "REFUND":
+      return { ...sub, id: rid("refund"), type: "REFUND", price: -9.99 };
+    case "REFUND_REVERSED":
+      return {
+        ...sub,
+        id: rid("reversed"),
+        type: "REFUND_REVERSED",
+        expiration_at_ms: now + 30 * DAY,
+      };
+    case "NON_RENEWING":
+      return {
+        ...sub,
+        id: rid("otp"),
+        type: "NON_RENEWING_PURCHASE",
+        product_id: "lifetime",
+        entitlement_ids: ["TEST Pro"],
+        transaction_id: `sim-otp-${appUserId}`,
+        original_transaction_id: `sim-otp-${appUserId}`,
+      };
+    case "TEMP_GRANT":
+      return {
+        ...sub,
+        id: rid("temp"),
+        type: "TEMPORARY_ENTITLEMENT_GRANT",
+        expiration_at_ms: now + DAY,
+      };
+    case "INVOICE":
+      return {
+        ...sub,
+        id: rid("inv"),
+        type: "INVOICE_ISSUANCE",
+        price_in_purchased_currency: 9.99,
+      };
+    case "VC_GRANT":
+      return {
+        id: rid("vcg"),
+        app_id: "app_demo",
+        app_user_id: appUserId,
+        environment: "PRODUCTION",
+        event_timestamp_ms: now,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        virtual_currency_transaction_id: rid("vc"),
+        source: "in_app_purchase",
+        adjustments: [
+          { amount: 500, currency: { code: "COINS", name: "Gold Coins" } },
+        ],
+      };
+    case "VC_SPEND":
+      return {
+        id: rid("vcs"),
+        app_id: "app_demo",
+        app_user_id: appUserId,
+        environment: "PRODUCTION",
+        event_timestamp_ms: now,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        virtual_currency_transaction_id: rid("vc"),
+        source: "spend",
+        adjustments: [
+          { amount: -100, currency: { code: "COINS", name: "Gold Coins" } },
+        ],
+      };
+    case "EXPERIMENT":
+      return {
+        ...sub,
+        id: rid("exp"),
+        type: "EXPERIMENT_ENROLLMENT",
+        experiment_id: "paywall_color_test",
+        experiment_variant: "B",
+        offering_id: "default",
+        enrolled_at_ms: now,
+      };
+    case "TRANSFER":
+      return {
+        id: rid("xfer"),
+        app_id: "app_demo",
+        environment: "PRODUCTION",
+        event_timestamp_ms: now,
+        type: "TRANSFER",
+        transferred_from: [appUserId],
+        transferred_to: [toAppUserId],
+        entitlement_ids: ["TEST Pro"],
+      };
+    case "REDEEM":
+      return {
+        id: rid("redeem"),
+        app_id: "app_demo",
+        environment: "PRODUCTION",
+        event_timestamp_ms: now,
+        type: "PURCHASE_REDEEMED",
+        redeemed_from: [toAppUserId],
+        redeemed_by: [appUserId],
+        redemption_outcome: "alias",
+        entitlement_ids: ["TEST Pro"],
+      };
+    case "TEST":
+      return { ...sub, id: rid("test"), type: "TEST" };
+    default:
+      return { ...sub, id: rid("evt"), type: scenario };
+  }
+}
+
+export const fire = mutation({
+  args: {
+    appUserId: v.string(),
+    scenario: v.string(),
+    toAppUserId: v.optional(v.string()),
+  },
+  returns: v.object({ processed: v.boolean(), type: v.string() }),
+  handler: async (ctx, args) => {
+    const event = buildEvent(
+      args.appUserId,
+      args.scenario,
+      args.toAppUserId ?? `${args.appUserId}-alt`,
+    );
+    const res = await ctx.runMutation(components.revenuecat.webhooks.process, {
+      event: {
+        id: event.id as string,
+        type: event.type as string,
+        app_id: event.app_id as string | undefined,
+        app_user_id: event.app_user_id as string | undefined,
+        environment: event.environment as "SANDBOX" | "PRODUCTION",
+        store: event.store as "APP_STORE" | undefined,
+      },
+      payload: event,
+    });
+    return { processed: res.processed, type: event.type as string };
+  },
+});

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>convex-revenuecat live demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,12 +1,68 @@
-import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useEffect, useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { Purchases, type Package } from "@revenuecat/purchases-js";
 import { api } from "../convex/_generated/api";
 
+// Fixed demo identity, no sign-in or manual entry. The Web SDK purchases as
+// this user, RevenueCat fires a webhook for it, and the panels below read it.
+const APP_USER_ID = "demo-user";
+const PARTNER = "demo-user-alt";
+const rcKey = import.meta.env.VITE_REVENUECAT_API_KEY as string;
 const siteUrl = (import.meta.env.VITE_CONVEX_URL as string).replace(
   ".convex.cloud",
   ".convex.site",
 );
 const webhookUrl = `${siteUrl}/webhooks/revenuecat`;
+
+function rc(): Purchases {
+  if (!Purchases.isConfigured())
+    Purchases.configure({ apiKey: rcKey, appUserId: APP_USER_ID });
+  return Purchases.getSharedInstance();
+}
+
+// Events RevenueCat won't emit on demand (billing issues, expiration, refunds,
+// transfers, currency...) so they're simulated through the real webhook path.
+const GROUPS: { group: string; items: [string, string][] }[] = [
+  {
+    group: "Subscription lifecycle",
+    items: [
+      ["RENEWAL", "Renew"],
+      ["PRODUCT_CHANGE", "Change plan"],
+      ["EXTEND", "Extend"],
+      ["UNSUBSCRIBE", "Unsubscribe"],
+      ["UNCANCELLATION", "Re-subscribe"],
+      ["PAUSE", "Pause"],
+    ],
+  },
+  {
+    group: "Billing & refunds",
+    items: [
+      ["BILLING_ISSUE", "Billing issue → grace"],
+      ["EXPIRATION", "Expire → revoke"],
+      ["REFUND", "Refund"],
+      ["REFUND_REVERSED", "Refund reversed"],
+    ],
+  },
+  {
+    group: "One-time & currency",
+    items: [
+      ["NON_RENEWING", "Non-renewing purchase"],
+      ["TEMP_GRANT", "Temporary grant"],
+      ["VC_GRANT", "Grant 500 coins"],
+      ["VC_SPEND", "Spend 100 coins"],
+      ["INVOICE", "Issue invoice"],
+    ],
+  },
+  {
+    group: "Identity & other",
+    items: [
+      ["EXPERIMENT", "Enroll experiment"],
+      ["TRANSFER", "Transfer out →"],
+      ["REDEEM", "Redeem (alias in)"],
+      ["TEST", "Test event"],
+    ],
+  },
+];
 
 const mono = { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" };
 const card: React.CSSProperties = {
@@ -15,6 +71,8 @@ const card: React.CSSProperties = {
   borderRadius: 10,
   padding: "14px 16px",
 };
+const dt = (ms?: number | null) => (ms ? new Date(ms).toLocaleString() : "—");
+const empty = <span style={{ color: "#94a3b8", fontSize: 13 }}>none</span>;
 
 function Badge({ ok, label }: { ok: boolean; label: string }) {
   return (
@@ -33,100 +91,322 @@ function Badge({ ok, label }: { ok: boolean; label: string }) {
     </span>
   );
 }
-
-function Card({ title, count, children }: { title: string; count?: number; children: React.ReactNode }) {
+function Card({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: React.ReactNode;
+}) {
   return (
     <div style={card}>
-      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 10 }}>
-        <strong style={{ fontSize: 13, textTransform: "uppercase", letterSpacing: 0.4, color: "#475569" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 10,
+        }}
+      >
+        <strong
+          style={{
+            fontSize: 13,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+            color: "#475569",
+          }}
+        >
           {title}
         </strong>
-        {count !== undefined && <span style={{ ...mono, color: "#94a3b8", fontSize: 12 }}>{count}</span>}
+        {count !== undefined && (
+          <span style={{ ...mono, color: "#94a3b8", fontSize: 12 }}>
+            {count}
+          </span>
+        )}
       </div>
       {children}
     </div>
   );
 }
-
-const dt = (ms?: number | null) => (ms ? new Date(ms).toLocaleString() : "—");
-const empty = <span style={{ color: "#94a3b8", fontSize: 13 }}>none</span>;
+const btn: React.CSSProperties = {
+  ...mono,
+  fontSize: 12,
+  padding: "6px 10px",
+  borderRadius: 7,
+  border: "1px solid #cbd5e1",
+  background: "#f8fafc",
+  color: "#0f172a",
+  cursor: "pointer",
+};
 
 export function App() {
-  const [input, setInput] = useState("");
-  const [appUserId, setAppUserId] = useState("");
-  const status = useQuery(api.demo.status, appUserId ? { appUserId } : "skip");
-  const events = useQuery(api.demo.recentEvents, appUserId ? { appUserId } : "skip");
+  const [pkgs, setPkgs] = useState<Package[] | null>(null);
+  const [offErr, setOffErr] = useState<string | null>(null);
+  const [buyMsg, setBuyMsg] = useState<string | null>(null);
+  const [simMsg, setSimMsg] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const status = useQuery(api.demo.status, { appUserId: APP_USER_ID });
+  const events = useQuery(api.demo.recentEvents, { appUserId: APP_USER_ID });
+  const fire = useMutation(api.simulate.fire);
+
+  useEffect(() => {
+    rc()
+      .getOfferings()
+      .then((o) => setPkgs(o.current?.availablePackages ?? []))
+      .catch((e) => setOffErr(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  async function buy(pkg: Package) {
+    setBuyMsg(`opening checkout for ${pkg.webBillingProduct.title}…`);
+    try {
+      await rc().purchase({ rcPackage: pkg });
+      setBuyMsg(
+        `purchased ${pkg.webBillingProduct.title} — webhook landing below`,
+      );
+    } catch (e) {
+      setBuyMsg(`purchase: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  async function sim(scenario: string) {
+    setBusy(true);
+    try {
+      const r = await fire({
+        appUserId: APP_USER_ID,
+        scenario,
+        toAppUserId: PARTNER,
+      });
+      setSimMsg(`${r.type} → ${r.processed ? "processed" : "ignored"}`);
+    } catch (e) {
+      setSimMsg(`error: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   return (
-    <div style={{ maxWidth: 980, margin: "0 auto", padding: 24, fontFamily: "system-ui, sans-serif", color: "#0f172a" }}>
+    <div
+      style={{
+        maxWidth: 1080,
+        margin: "0 auto",
+        padding: 24,
+        fontFamily: "system-ui, sans-serif",
+        color: "#0f172a",
+      }}
+    >
       <h1 style={{ marginBottom: 4 }}>convex-revenuecat</h1>
       <p style={{ color: "#64748b", marginTop: 0 }}>
-        Live subscription state, driven entirely by RevenueCat webhooks. Send an event from the RevenueCat
-        dashboard (or make a Test Store purchase) and watch this update in real time.
+        Real purchases through the RevenueCat Web SDK, plus a simulator for the
+        events RevenueCat won't emit on demand. Every action drives the live
+        component state below, no sign-in, watching{" "}
+        <code style={mono}>{APP_USER_ID}</code>.
       </p>
-      <div style={{ ...card, ...mono, fontSize: 12, color: "#475569", marginBottom: 20 }}>
+      <div
+        style={{
+          ...card,
+          ...mono,
+          fontSize: 12,
+          color: "#475569",
+          marginBottom: 20,
+        }}
+      >
         webhook → <span style={{ color: "#0f172a" }}>{webhookUrl}</span>
       </div>
 
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          setAppUserId(input.trim());
-        }}
-        style={{ display: "flex", gap: 8, marginBottom: 20 }}
-      >
-        <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="app_user_id from RevenueCat (e.g. the one your test event used)"
-          style={{ ...mono, flex: 1, padding: "10px 12px", border: "1px solid #cbd5e1", borderRadius: 8, fontSize: 14 }}
-        />
-        <button
-          type="submit"
-          style={{ padding: "10px 18px", border: 0, borderRadius: 8, background: "#0f172a", color: "#fff", fontSize: 14, cursor: "pointer" }}
+      <div style={{ ...card, marginBottom: 14 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: 10,
+          }}
         >
-          Watch
-        </button>
-      </form>
+          <strong
+            style={{
+              fontSize: 13,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+              color: "#475569",
+            }}
+          >
+            Buy (real RevenueCat purchase)
+          </strong>
+          {buyMsg && (
+            <span style={{ ...mono, fontSize: 12, color: "#166534" }}>
+              {buyMsg}
+            </span>
+          )}
+        </div>
+        {offErr ? (
+          <span style={{ ...mono, fontSize: 12, color: "#b91c1c" }}>
+            offerings: {offErr}
+          </span>
+        ) : pkgs === null ? (
+          <span style={{ color: "#94a3b8", fontSize: 13 }}>
+            loading offering…
+          </span>
+        ) : pkgs.length === 0 ? (
+          empty
+        ) : (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {pkgs.map((p) => (
+              <button
+                key={p.identifier}
+                onClick={() => buy(p)}
+                style={{
+                  ...btn,
+                  background: "#0f172a",
+                  color: "#fff",
+                  border: 0,
+                  padding: "8px 14px",
+                  fontSize: 13,
+                }}
+              >
+                {p.webBillingProduct.title}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
 
-      {!appUserId ? (
-        <p style={{ color: "#94a3b8" }}>Enter an app_user_id to start watching.</p>
-      ) : status === undefined ? (
-        <p style={{ color: "#94a3b8" }}>Loading…</p>
+      <div style={{ ...card, marginBottom: 20 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: 12,
+          }}
+        >
+          <strong
+            style={{
+              fontSize: 13,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+              color: "#475569",
+            }}
+          >
+            Simulate webhook
+          </strong>
+          {simMsg && (
+            <span
+              style={{
+                ...mono,
+                fontSize: 12,
+                color: busy ? "#94a3b8" : "#166534",
+              }}
+            >
+              {simMsg}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 18 }}>
+          {GROUPS.map((g) => (
+            <div key={g.group}>
+              <div
+                style={{
+                  fontSize: 11,
+                  color: "#94a3b8",
+                  marginBottom: 6,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.4,
+                }}
+              >
+                {g.group}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 6,
+                  maxWidth: 250,
+                }}
+              >
+                {g.items.map(([scenario, label]) => (
+                  <button
+                    key={scenario}
+                    onClick={() => sim(scenario)}
+                    disabled={busy}
+                    style={{ ...btn, opacity: busy ? 0.5 : 1 }}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {status === undefined ? (
+        <p style={{ color: "#94a3b8" }}>Loading {APP_USER_ID}…</p>
       ) : (
         <>
           <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
-            <Badge ok={status.isSubscriber} label={status.isSubscriber ? "subscriber" : "not subscribed"} />
-            <Badge ok={status.isInTrial} label={status.isInTrial ? "in trial / intro" : "not in trial"} />
-            <Badge ok={status.gracePeriod.length > 0} label={`${status.gracePeriod.length} in grace`} />
+            <Badge
+              ok={status.isSubscriber}
+              label={status.isSubscriber ? "subscriber" : "not subscribed"}
+            />
+            <Badge
+              ok={status.isInTrial}
+              label={status.isInTrial ? "in trial / intro" : "not in trial"}
+            />
+            <Badge
+              ok={status.gracePeriod.length > 0}
+              label={`${status.gracePeriod.length} in grace`}
+            />
           </div>
-
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-            <Card title="Active entitlements" count={status.activeEntitlements.length}>
+          <div
+            style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}
+          >
+            <Card
+              title="Active entitlements"
+              count={status.activeEntitlements.length}
+            >
               {status.activeEntitlements.length === 0
                 ? empty
                 : status.activeEntitlements.map((e) => (
-                    <div key={e._id} style={{ ...mono, fontSize: 13, padding: "4px 0", borderBottom: "1px solid #f1f5f9" }}>
-                      <strong>{e.entitlementId}</strong> · {e.store ?? "?"} · expires {dt(e.expiresAtMs)}
+                    <div
+                      key={e._id}
+                      style={{
+                        ...mono,
+                        fontSize: 13,
+                        padding: "4px 0",
+                        borderBottom: "1px solid #f1f5f9",
+                      }}
+                    >
+                      <strong>{e.entitlementId}</strong> · {e.store ?? "?"} ·
+                      expires {dt(e.expiresAtMs)}
                     </div>
                   ))}
             </Card>
-
             <Card title="Subscriptions" count={status.subscriptions.length}>
               {status.subscriptions.length === 0
                 ? empty
                 : status.subscriptions.map((s) => (
-                    <div key={s._id} style={{ ...mono, fontSize: 13, padding: "4px 0", borderBottom: "1px solid #f1f5f9" }}>
-                      <strong>{s.productId}</strong> · {s.periodType} · renews {s.autoRenewStatus ? "yes" : "no"} · exp {dt(s.expirationAtMs)}
+                    <div
+                      key={s._id}
+                      style={{
+                        ...mono,
+                        fontSize: 13,
+                        padding: "4px 0",
+                        borderBottom: "1px solid #f1f5f9",
+                      }}
+                    >
+                      <strong>{s.productId}</strong> · {s.periodType} · renews{" "}
+                      {s.autoRenewStatus ? "yes" : "no"} · exp{" "}
+                      {dt(s.expirationAtMs)}
                     </div>
                   ))}
             </Card>
-
             <Card title="Customer">
               {status.customer ? (
                 <div style={{ ...mono, fontSize: 13, lineHeight: 1.7 }}>
                   <div>original: {status.customer.originalAppUserId}</div>
-                  <div>aliases: {status.customer.aliases.join(", ") || "—"}</div>
+                  <div>
+                    aliases: {status.customer.aliases.join(", ") || "—"}
+                  </div>
                   <div>country: {status.customer.countryCode ?? "—"}</div>
                   <div>first seen: {dt(status.customer.firstSeenAt)}</div>
                 </div>
@@ -134,36 +414,60 @@ export function App() {
                 empty
               )}
             </Card>
-
-            <Card title="Virtual currency" count={status.virtualCurrency.length}>
+            <Card
+              title="Virtual currency"
+              count={status.virtualCurrency.length}
+            >
               {status.virtualCurrency.length === 0
                 ? empty
                 : status.virtualCurrency.map((b) => (
-                    <div key={b._id} style={{ ...mono, fontSize: 13, padding: "4px 0" }}>
+                    <div
+                      key={b._id}
+                      style={{ ...mono, fontSize: 13, padding: "4px 0" }}
+                    >
                       <strong>{b.currencyCode}</strong>: {b.balance}
                     </div>
                   ))}
             </Card>
-
             <Card title="Invoices" count={status.invoices.length}>
               {status.invoices.length === 0
                 ? empty
                 : status.invoices.map((i) => (
-                    <div key={i._id} style={{ ...mono, fontSize: 13, padding: "4px 0" }}>
-                      {i.productId ?? "?"} · {i.priceUsd != null ? `$${i.priceUsd}` : "—"} · {dt(i.issuedAt)}
+                    <div
+                      key={i._id}
+                      style={{ ...mono, fontSize: 13, padding: "4px 0" }}
+                    >
+                      {i.productId ?? "?"} ·{" "}
+                      {i.priceUsd != null ? `$${i.priceUsd}` : "—"} ·{" "}
+                      {dt(i.issuedAt)}
                     </div>
                   ))}
             </Card>
-
             <Card title="Recent webhook events" count={events?.length}>
               {!events || events.length === 0
                 ? empty
                 : events.map((ev) => (
-                    <div key={ev._id} style={{ ...mono, fontSize: 12, padding: "3px 0", display: "flex", justifyContent: "space-between" }}>
+                    <div
+                      key={ev._id}
+                      style={{
+                        ...mono,
+                        fontSize: 12,
+                        padding: "3px 0",
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: 8,
+                      }}
+                    >
                       <span>
-                        <Badge ok={ev.status === "processed"} label={ev.status} /> {ev.eventType}
+                        <Badge
+                          ok={ev.status === "processed"}
+                          label={ev.status}
+                        />{" "}
+                        {ev.eventType}
                       </span>
-                      <span style={{ color: "#94a3b8" }}>{dt(ev.processedAt)}</span>
+                      <span style={{ color: "#94a3b8" }}>
+                        {dt(ev.processedAt)}
+                      </span>
                     </div>
                   ))}
             </Card>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+
+const siteUrl = (import.meta.env.VITE_CONVEX_URL as string).replace(
+  ".convex.cloud",
+  ".convex.site",
+);
+const webhookUrl = `${siteUrl}/webhooks/revenuecat`;
+
+const mono = { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" };
+const card: React.CSSProperties = {
+  background: "#fff",
+  border: "1px solid #e5e7eb",
+  borderRadius: 10,
+  padding: "14px 16px",
+};
+
+function Badge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span
+      style={{
+        ...mono,
+        fontSize: 12,
+        padding: "3px 9px",
+        borderRadius: 999,
+        background: ok ? "#dcfce7" : "#f1f5f9",
+        color: ok ? "#166534" : "#64748b",
+        border: `1px solid ${ok ? "#86efac" : "#e2e8f0"}`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function Card({ title, count, children }: { title: string; count?: number; children: React.ReactNode }) {
+  return (
+    <div style={card}>
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 10 }}>
+        <strong style={{ fontSize: 13, textTransform: "uppercase", letterSpacing: 0.4, color: "#475569" }}>
+          {title}
+        </strong>
+        {count !== undefined && <span style={{ ...mono, color: "#94a3b8", fontSize: 12 }}>{count}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const dt = (ms?: number | null) => (ms ? new Date(ms).toLocaleString() : "—");
+const empty = <span style={{ color: "#94a3b8", fontSize: 13 }}>none</span>;
+
+export function App() {
+  const [input, setInput] = useState("");
+  const [appUserId, setAppUserId] = useState("");
+  const status = useQuery(api.demo.status, appUserId ? { appUserId } : "skip");
+  const events = useQuery(api.demo.recentEvents, appUserId ? { appUserId } : "skip");
+
+  return (
+    <div style={{ maxWidth: 980, margin: "0 auto", padding: 24, fontFamily: "system-ui, sans-serif", color: "#0f172a" }}>
+      <h1 style={{ marginBottom: 4 }}>convex-revenuecat</h1>
+      <p style={{ color: "#64748b", marginTop: 0 }}>
+        Live subscription state, driven entirely by RevenueCat webhooks. Send an event from the RevenueCat
+        dashboard (or make a Test Store purchase) and watch this update in real time.
+      </p>
+      <div style={{ ...card, ...mono, fontSize: 12, color: "#475569", marginBottom: 20 }}>
+        webhook → <span style={{ color: "#0f172a" }}>{webhookUrl}</span>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          setAppUserId(input.trim());
+        }}
+        style={{ display: "flex", gap: 8, marginBottom: 20 }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="app_user_id from RevenueCat (e.g. the one your test event used)"
+          style={{ ...mono, flex: 1, padding: "10px 12px", border: "1px solid #cbd5e1", borderRadius: 8, fontSize: 14 }}
+        />
+        <button
+          type="submit"
+          style={{ padding: "10px 18px", border: 0, borderRadius: 8, background: "#0f172a", color: "#fff", fontSize: 14, cursor: "pointer" }}
+        >
+          Watch
+        </button>
+      </form>
+
+      {!appUserId ? (
+        <p style={{ color: "#94a3b8" }}>Enter an app_user_id to start watching.</p>
+      ) : status === undefined ? (
+        <p style={{ color: "#94a3b8" }}>Loading…</p>
+      ) : (
+        <>
+          <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+            <Badge ok={status.isSubscriber} label={status.isSubscriber ? "subscriber" : "not subscribed"} />
+            <Badge ok={status.isInTrial} label={status.isInTrial ? "in trial / intro" : "not in trial"} />
+            <Badge ok={status.gracePeriod.length > 0} label={`${status.gracePeriod.length} in grace`} />
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <Card title="Active entitlements" count={status.activeEntitlements.length}>
+              {status.activeEntitlements.length === 0
+                ? empty
+                : status.activeEntitlements.map((e) => (
+                    <div key={e._id} style={{ ...mono, fontSize: 13, padding: "4px 0", borderBottom: "1px solid #f1f5f9" }}>
+                      <strong>{e.entitlementId}</strong> · {e.store ?? "?"} · expires {dt(e.expiresAtMs)}
+                    </div>
+                  ))}
+            </Card>
+
+            <Card title="Subscriptions" count={status.subscriptions.length}>
+              {status.subscriptions.length === 0
+                ? empty
+                : status.subscriptions.map((s) => (
+                    <div key={s._id} style={{ ...mono, fontSize: 13, padding: "4px 0", borderBottom: "1px solid #f1f5f9" }}>
+                      <strong>{s.productId}</strong> · {s.periodType} · renews {s.autoRenewStatus ? "yes" : "no"} · exp {dt(s.expirationAtMs)}
+                    </div>
+                  ))}
+            </Card>
+
+            <Card title="Customer">
+              {status.customer ? (
+                <div style={{ ...mono, fontSize: 13, lineHeight: 1.7 }}>
+                  <div>original: {status.customer.originalAppUserId}</div>
+                  <div>aliases: {status.customer.aliases.join(", ") || "—"}</div>
+                  <div>country: {status.customer.countryCode ?? "—"}</div>
+                  <div>first seen: {dt(status.customer.firstSeenAt)}</div>
+                </div>
+              ) : (
+                empty
+              )}
+            </Card>
+
+            <Card title="Virtual currency" count={status.virtualCurrency.length}>
+              {status.virtualCurrency.length === 0
+                ? empty
+                : status.virtualCurrency.map((b) => (
+                    <div key={b._id} style={{ ...mono, fontSize: 13, padding: "4px 0" }}>
+                      <strong>{b.currencyCode}</strong>: {b.balance}
+                    </div>
+                  ))}
+            </Card>
+
+            <Card title="Invoices" count={status.invoices.length}>
+              {status.invoices.length === 0
+                ? empty
+                : status.invoices.map((i) => (
+                    <div key={i._id} style={{ ...mono, fontSize: 13, padding: "4px 0" }}>
+                      {i.productId ?? "?"} · {i.priceUsd != null ? `$${i.priceUsd}` : "—"} · {dt(i.issuedAt)}
+                    </div>
+                  ))}
+            </Card>
+
+            <Card title="Recent webhook events" count={events?.length}>
+              {!events || events.length === 0
+                ? empty
+                : events.map((ev) => (
+                    <div key={ev._id} style={{ ...mono, fontSize: 12, padding: "3px 0", display: "flex", justifyContent: "space-between" }}>
+                      <span>
+                        <Badge ok={ev.status === "processed"} label={ev.status} /> {ev.eventType}
+                      </span>
+                      <span style={{ color: "#94a3b8" }}>{dt(ev.processedAt)}</span>
+                    </div>
+                  ))}
+            </Card>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <ConvexProvider client={convex}>
+      <App />
+    </ConvexProvider>
+  </React.StrictMode>,
+);

--- a/example/tsconfig.app.json
+++ b/example/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": false,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"]
+}

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Serves the showcase from example/. The Convex functions live in
+// example/convex and run on the linked dev deployment (VITE_CONVEX_URL).
+export default defineConfig({
+  plugins: [react()],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "@edge-runtime/vm": "^5.0.0",
         "@eslint/js": "10.0.1",
         "@types/node": "^25.6.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "4.1.4",
         "chokidar-cli": "3.0.0",
         "convex": "1.35.1",
@@ -25,8 +28,11 @@
         "jiti": "^2.6.1",
         "pkg-pr-new": "0.0.66",
         "prettier": "3.8.3",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "6.0.3",
         "typescript-eslint": "^8.58.2",
+        "vite": "^6.0.0",
         "vitest": "4.1.4"
       },
       "engines": {
@@ -75,10 +81,179 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -86,23 +261,47 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -111,15 +310,81 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -170,40 +435,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -789,6 +1020,28 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -831,25 +1084,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@octokit/action": {
@@ -1124,20 +1358,31 @@
         "@octokit/openapi-types": "^20.0.0"
       }
     },
-    "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
+      "optional": true,
+      "os": [
+        "android"
+      ]
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -1146,15 +1391,12 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -1163,15 +1405,12 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -1180,15 +1419,26 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -1197,100 +1447,233 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -1298,33 +1681,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+        "openbsd"
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -1333,34 +1696,12 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -1369,15 +1710,26 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -1386,17 +1738,21 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1405,15 +1761,49 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/chai": {
@@ -1463,6 +1853,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1708,6 +2118,27 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
@@ -1948,6 +2379,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -1994,12 +2438,67 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2178,6 +2677,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2220,15 +2726,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
@@ -2283,6 +2786,16 @@
         "@esbuild/win32-arm64": "0.27.0",
         "@esbuild/win32-ia32": "0.27.0",
         "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2622,6 +3135,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2827,6 +3350,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2847,6 +3383,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2870,267 +3419,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -3162,6 +3450,16 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3262,6 +3560,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3546,6 +3854,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3576,39 +3917,57 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@types/estree": "1.0.8"
       },
       "bin": {
-        "rolldown": "bin/cli.mjs"
+        "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3849,14 +4208,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -3959,6 +4310,37 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3990,23 +4372,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4015,15 +4398,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -4032,16 +4414,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
         "jiti": {
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -4063,6 +4442,508 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
           "optional": true
         }
       }
@@ -4310,6 +5191,13 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@convex-dev/eslint-plugin": "^2.0.0",
         "@edge-runtime/vm": "^5.0.0",
         "@eslint/js": "10.0.1",
+        "@revenuecat/purchases-js": "^1.41.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1357,6 +1358,13 @@
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
       }
+    },
+    "node_modules/@revenuecat/purchases-js": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js/-/purchases-js-1.41.1.tgz",
+      "integrity": "sha512-v6vunZZ4YnQhR/O4W3cVhw3iE8O8fhloNA9Al3KU6ABiH6YGjflJiOhjbTp8JG78eUOlYUFYZwEU8H0VXSuiYA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@convex-dev/eslint-plugin": "^2.0.0",
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "10.0.1",
+    "@revenuecat/purchases-js": "^1.41.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "test:watch": "vitest --typecheck --clearScreen false",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text",
-    "validate": "npm test && npm run lint && npm run typecheck"
+    "validate": "npm test && npm run lint && npm run typecheck",
+    "example": "vite example",
+    "example:build": "vite build example"
   },
   "files": [
     "dist",
@@ -93,6 +95,9 @@
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "10.0.1",
     "@types/node": "^25.6.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "4.1.4",
     "chokidar-cli": "3.0.0",
     "convex": "1.35.1",
@@ -102,8 +107,11 @@
     "jiti": "^2.6.1",
     "pkg-pr-new": "0.0.66",
     "prettier": "3.8.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "6.0.3",
     "typescript-eslint": "^8.58.2",
+    "vite": "^6.0.0",
     "vitest": "4.1.4"
   },
   "types": "./dist/client/index.d.ts",

--- a/src/client/component-contract.test.ts
+++ b/src/client/component-contract.test.ts
@@ -1,22 +1,47 @@
 import { expect, test } from "vitest";
 import { RevenueCat } from "./index.js";
+import type { FunctionReference } from "convex/server";
 import type { ComponentApi } from "../component/_generated/component.js";
 
-// A deployed consumer's `components.revenuecat` resolves to
-// `ComponentApi<"revenuecat">`. It must satisfy the `RevenueCat` constructor so
-// the documented `new RevenueCat(components.revenuecat, ...)` call typechecks.
-// The example app only exercises this via its committed precise generated
-// types; this locks the contract directly, so drift between the generated
-// component API and the client constructor fails CI. (The pre-`convex dev`
-// `AnyComponents` stub is a separate, expected Convex limitation.)
 type Expect<T extends true> = T;
-type ComponentApiSatisfiesCtor = Expect<
+
+// 1. A deployed consumer's `components.revenuecat` resolves to
+//    `ComponentApi<"revenuecat">`, which must satisfy the `RevenueCat`
+//    constructor so the documented `new RevenueCat(components.revenuecat, ...)`
+//    call typechecks.
+type CtorAcceptsComponentApi = Expect<
   ComponentApi<"revenuecat"> extends ConstructorParameters<typeof RevenueCat>[0]
     ? true
     : false
 >;
 
-test("generated ComponentApi satisfies the RevenueCat constructor", () => {
-  const enforced: ComponentApiSatisfiesCtor = true;
-  expect(enforced).toBe(true);
+// 2. `component.ts` is real `npx convex codegen` output. Convex omits a
+//    component's internalMutation/internalQuery from ComponentApi entirely and
+//    emits the PUBLIC ones with "internal" visibility. Lock the
+//    parent/consumer-called functions: if any is switched to internalMutation
+//    it vanishes from ComponentApi and this typecheck fails, which is exactly
+//    the break that left the client unable to call `webhooks.process`.
+type IsInternal<T> =
+  T extends FunctionReference<any, "internal", any, any, any> ? true : false;
+type Api = ComponentApi<"revenuecat">;
+type AllTrue<_T extends readonly true[]> = true;
+type ParentCallableArePresent = AllTrue<
+  [
+    // Called by the client (src/client/index.ts).
+    IsInternal<Api["webhooks"]["process"]>,
+    IsInternal<Api["webhooks"]["recordFailure"]>,
+    IsInternal<Api["customers"]["get"]>,
+    IsInternal<Api["customers"]["purge"]>,
+    IsInternal<Api["entitlements"]["check"]>,
+    IsInternal<Api["sync"]["ingest"]>,
+    // Called by the consumer's upgrade action (see README).
+    IsInternal<Api["subscriptions"]["backfillKind"]>,
+    IsInternal<Api["transfers"]["backfillTransferParticipants"]>,
+  ]
+>;
+
+test("ComponentApi: ctor contract + parent-callable functions present", () => {
+  const ctor: CtorAcceptsComponentApi = true;
+  const present: ParentCallableArePresent = true;
+  expect(ctor && present).toBe(true);
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -475,7 +475,11 @@ export class RevenueCat {
 
   /** Purge all component-local data for a user. Returns per-table counts.
    * Does NOT call RC's REST API. Wrap a Convex action around
-   * `DELETE /v1/subscribers/{id}` if you need that too. */
+   * `DELETE /v1/subscribers/{id}` if you need that too.
+   *
+   * Destructive and unauthenticated: it purges whatever `appUserId` you pass.
+   * Never expose it in a public mutation that takes `appUserId` from the
+   * client. Gate it behind your own auth/role check (e.g. an internal action). */
   async deleteCustomer(
     ctx: MutCtx,
     args: { appUserId: string },
@@ -596,7 +600,9 @@ export class RevenueCat {
     return subs.length > 0;
   }
 
-  /** True when any active subscription is in TRIAL or INTRO period. */
+  /** True when any active subscription is in a TRIAL (free) or INTRO (paid
+   * introductory) period. For free-trial-only semantics, check
+   * `periodType === "TRIAL"` directly. */
   async isInTrial(ctx: QueryCtx, args: { appUserId: string }): Promise<boolean> {
     const subs = (await ctx.runQuery(this.component.subscriptions.getActive, {
       appUserId: args.appUserId,

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as cleanup from "../cleanup.js";
+import type * as crons from "../crons.js";
 import type * as customers from "../customers.js";
 import type * as entitlements from "../entitlements.js";
 import type * as experiments from "../experiments.js";
@@ -18,15 +19,22 @@ import type * as lib from "../lib.js";
 import type * as subscriptions from "../subscriptions.js";
 import type * as sync from "../sync.js";
 import type * as transfers from "../transfers.js";
+import type * as transitions from "../transitions.js";
+import type * as types from "../types.js";
 import type * as virtualCurrency from "../virtualCurrency.js";
 import type * as webhookEvents from "../webhookEvents.js";
 import type * as webhooks from "../webhooks.js";
 
-import type { ApiFromModules, FilterApi, FunctionReference } from "convex/server";
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   cleanup: typeof cleanup;
+  crons: typeof crons;
   customers: typeof customers;
   entitlements: typeof entitlements;
   experiments: typeof experiments;
@@ -36,6 +44,8 @@ const fullApi: ApiFromModules<{
   subscriptions: typeof subscriptions;
   sync: typeof sync;
   transfers: typeof transfers;
+  transitions: typeof transitions;
+  types: typeof types;
   virtualCurrency: typeof virtualCurrency;
   webhookEvents: typeof webhookEvents;
   webhooks: typeof webhooks;
@@ -49,7 +59,10 @@ const fullApi: ApiFromModules<{
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-export const api: FilterApi<typeof fullApi, FunctionReference<any, "public">> = anyApi as any;
+export const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+> = anyApi as any;
 
 /**
  * A utility for referencing Convex functions in your app's internal API.

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -10,438 +10,884 @@
 
 import type { FunctionReference } from "convex/server";
 
-type Store =
-  | "AMAZON"
-  | "APP_STORE"
-  | "EXTERNAL"
-  | "GALAXY"
-  | "MAC_APP_STORE"
-  | "PADDLE"
-  | "PLAY_STORE"
-  | "PROMOTIONAL"
-  | "RC_BILLING"
-  | "ROKU"
-  | "STRIPE"
-  | "TEST_STORE"
-  | "UNKNOWN_STORE";
-
-type Environment = "SANDBOX" | "PRODUCTION";
-type PeriodType = "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
-// PURCHASED = direct purchase, FAMILY_SHARED = received via Family Sharing,
-// UNKNOWN = ownership not reported by the store (real Android SDK wire value)
-type OwnershipType = "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
-
-interface EntitlementDoc {
-  _id: string;
-  _creationTime: number;
-  appUserId: string;
-  entitlementId: string;
-  productId?: string;
-  isActive: boolean;
-  expiresAtMs?: number;
-  purchasedAtMs?: number;
-  store?: Store;
-  isSandbox: boolean;
-  unsubscribeDetectedAt?: number;
-  billingIssueDetectedAt?: number;
-  ownershipType?: OwnershipType;
-  updatedAt: number;
-}
-
-interface SubscriptionDoc {
-  _id: string;
-  _creationTime: number;
-  appUserId: string;
-  productId: string;
-  kind?: "subscription" | "consumable";
-  entitlementIds?: string[];
-  store: Store;
-  environment: Environment;
-  periodType: PeriodType;
-  purchasedAtMs: number;
-  expirationAtMs?: number;
-  originalTransactionId: string;
-  transactionId: string;
-  isFamilyShare: boolean;
-  ownershipType?: OwnershipType;
-  isTrialConversion?: boolean;
-  autoRenewStatus?: boolean;
-  cancelReason?: string;
-  expirationReason?: string;
-  gracePeriodExpirationAtMs?: number;
-  billingIssueDetectedAt?: number;
-  autoResumeAtMs?: number;
-  priceUsd?: number;
-  currency?: string;
-  priceInPurchasedCurrency?: number;
-  countryCode?: string;
-  taxPercentage?: number;
-  commissionPercentage?: number;
-  offerCode?: string;
-  presentedOfferingId?: string;
-  renewalNumber?: number;
-  newProductId?: string;
-  refundedAtMs?: number;
-  originalPurchasedAtMs?: number;
-  unsubscribeDetectedAt?: number;
-  updatedAt: number;
-}
-
-interface GracePeriodStatus {
-  inGracePeriod: boolean;
-  gracePeriodExpiresAt?: number;
-  billingIssueDetectedAt?: number;
-}
-
-interface CustomerDoc {
-  _id: string;
-  _creationTime: number;
-  appUserId: string;
-  originalAppUserId: string;
-  aliases: string[];
-  firstSeenAt: number;
-  lastSeenAt?: number;
-  attributes?: any;
-  countryCode?: string;
-  managementUrl?: string;
-  updatedAt: number;
-}
-
-interface ExperimentDoc {
-  _id: string;
-  _creationTime: number;
-  appUserId: string;
-  experimentId: string;
-  variant: string;
-  offeringId?: string;
-  enrolledAtMs: number;
-  updatedAt: number;
-}
-
-interface TransferDoc {
-  _id: string;
-  _creationTime: number;
-  eventId: string;
-  transferredFrom: string[];
-  transferredTo: string[];
-  entitlementIds?: string[];
-  timestamp: number;
-}
-
-interface InvoiceDoc {
-  _id: string;
-  _creationTime: number;
-  invoiceId: string;
-  appUserId: string;
-  productId?: string;
-  store?: Store;
-  environment: Environment;
-  priceUsd?: number;
-  currency?: string;
-  priceInPurchasedCurrency?: number;
-  issuedAt: number;
-}
-
-interface VirtualCurrencyBalanceDoc {
-  _id: string;
-  _creationTime: number;
-  appUserId: string;
-  currencyCode: string;
-  currencyName: string;
-  balance: number;
-  updatedAt: number;
-}
-
-interface VirtualCurrencyTransactionDoc {
-  _id: string;
-  _creationTime: number;
-  transactionId: string;
-  appUserId: string;
-  currencyCode: string;
-  amount: number;
-  source?: string;
-  productId?: string;
-  environment: Environment;
-  timestamp: number;
-}
-
-type WebhookEventStatus = "processed" | "failed" | "ignored";
-
-interface WebhookEventDoc {
-  _id: string;
-  _creationTime: number;
-  eventId: string;
-  eventType: string;
-  appId?: string;
-  appUserId?: string;
-  environment: Environment;
-  store?: Store;
-  payload: any;
-  processedAt: number;
-  status: WebhookEventStatus;
-  error?: string;
-}
-
 /**
  * A utility for referencing a Convex component's exposed API.
+ *
+ * Useful when expecting a parameter like `components.myComponent`.
+ * Usage:
+ * ```ts
+ * async function myFunction(ctx: QueryCtx, component: ComponentApi) {
+ *   return ctx.runQuery(component.someFile.someQuery, { ...args });
+ * }
+ * ```
  */
-export type ComponentApi<Name extends string | undefined = string | undefined> = {
-  customers: {
-    get: FunctionReference<"query", "public", { appUserId: string }, CustomerDoc | null, Name>;
-    getByOriginalId: FunctionReference<
-      "query",
-      "internal",
-      { originalAppUserId: string },
-      CustomerDoc | null,
-      Name
-    >;
-    purge: FunctionReference<
-      "mutation",
-      "public",
-      { appUserId: string; onCustomerDeleted?: string },
-      {
-        customer: number;
-        subscriptions: number;
-        entitlements: number;
-        experiments: number;
-        invoices: number;
-        virtualCurrencyBalances: number;
-        virtualCurrencyTransactions: number;
-        webhookEvents: number;
-        transfers: number;
-      },
-      Name
-    >;
+export type ComponentApi<Name extends string | undefined = string | undefined> =
+  {
+    customers: {
+      get: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        null | {
+          _creationTime: number;
+          _id: string;
+          aliases: Array<string>;
+          appUserId: string;
+          attributes?: Record<string, { updated_at_ms: number; value: string }>;
+          countryCode?: string;
+          firstSeenAt: number;
+          lastSeenAt?: number;
+          managementUrl?: string;
+          originalAppUserId: string;
+          updatedAt: number;
+        },
+        Name
+      >;
+      getByOriginalId: FunctionReference<
+        "query",
+        "internal",
+        { originalAppUserId: string },
+        null | {
+          _creationTime: number;
+          _id: string;
+          aliases: Array<string>;
+          appUserId: string;
+          attributes?: Record<string, { updated_at_ms: number; value: string }>;
+          countryCode?: string;
+          firstSeenAt: number;
+          lastSeenAt?: number;
+          managementUrl?: string;
+          originalAppUserId: string;
+          updatedAt: number;
+        },
+        Name
+      >;
+      purge: FunctionReference<
+        "mutation",
+        "internal",
+        { appUserId: string; onCustomerDeleted?: string },
+        {
+          customer: number;
+          entitlements: number;
+          experiments: number;
+          invoices: number;
+          subscriptions: number;
+          transfers: number;
+          virtualCurrencyBalances: number;
+          virtualCurrencyTransactions: number;
+          webhookEvents: number;
+        },
+        Name
+      >;
+    };
+    entitlements: {
+      check: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string; entitlementId: string },
+        boolean,
+        Name
+      >;
+      getActive: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          billingIssueDetectedAt?: number;
+          entitlementId: string;
+          expiresAtMs?: number;
+          isActive: boolean;
+          isSandbox: boolean;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          productId?: string;
+          purchasedAtMs?: number;
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      list: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          billingIssueDetectedAt?: number;
+          entitlementId: string;
+          expiresAtMs?: number;
+          isActive: boolean;
+          isSandbox: boolean;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          productId?: string;
+          purchasedAtMs?: number;
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+    };
+    experiments: {
+      get: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string; experimentId: string },
+        null | {
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          enrolledAtMs: number;
+          experimentId: string;
+          offeringId?: string;
+          updatedAt: number;
+          variant: string;
+        },
+        Name
+      >;
+      list: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          enrolledAtMs: number;
+          experimentId: string;
+          offeringId?: string;
+          updatedAt: number;
+          variant: string;
+        }>,
+        Name
+      >;
+      listByExperiment: FunctionReference<
+        "query",
+        "internal",
+        { experimentId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          enrolledAtMs: number;
+          experimentId: string;
+          offeringId?: string;
+          updatedAt: number;
+          variant: string;
+        }>,
+        Name
+      >;
+    };
+    invoices: {
+      get: FunctionReference<
+        "query",
+        "internal",
+        { invoiceId: string },
+        {
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          currency?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          invoiceId: string;
+          issuedAt: number;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId?: string;
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        } | null,
+        Name
+      >;
+      listByUser: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          currency?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          invoiceId: string;
+          issuedAt: number;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId?: string;
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        }>,
+        Name
+      >;
+    };
+    subscriptions: {
+      backfillKind: FunctionReference<
+        "mutation",
+        "internal",
+        { cursor?: string; pageSize?: number },
+        { nextCursor: string | null; scanned: number; written: number },
+        Name
+      >;
+      getActive: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          autoRenewStatus?: boolean;
+          autoResumeAtMs?: number;
+          billingIssueDetectedAt?: number;
+          cancelReason?: string;
+          commissionPercentage?: number;
+          countryCode?: string;
+          currency?: string;
+          entitlementIds?: Array<string>;
+          environment: "SANDBOX" | "PRODUCTION";
+          expirationAtMs?: number;
+          expirationReason?: string;
+          gracePeriodExpirationAtMs?: number;
+          isFamilyShare: boolean;
+          isTrialConversion?: boolean;
+          kind?: "subscription" | "consumable";
+          newProductId?: string;
+          offerCode?: string;
+          originalPurchasedAtMs?: number;
+          originalTransactionId: string;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          periodType: "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
+          presentedOfferingId?: string;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId: string;
+          purchasedAtMs: number;
+          refundedAtMs?: number;
+          renewalNumber?: number;
+          store:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          taxPercentage?: number;
+          transactionId: string;
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      getByOriginalTransaction: FunctionReference<
+        "query",
+        "internal",
+        { originalTransactionId: string },
+        null | {
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          autoRenewStatus?: boolean;
+          autoResumeAtMs?: number;
+          billingIssueDetectedAt?: number;
+          cancelReason?: string;
+          commissionPercentage?: number;
+          countryCode?: string;
+          currency?: string;
+          entitlementIds?: Array<string>;
+          environment: "SANDBOX" | "PRODUCTION";
+          expirationAtMs?: number;
+          expirationReason?: string;
+          gracePeriodExpirationAtMs?: number;
+          isFamilyShare: boolean;
+          isTrialConversion?: boolean;
+          kind?: "subscription" | "consumable";
+          newProductId?: string;
+          offerCode?: string;
+          originalPurchasedAtMs?: number;
+          originalTransactionId: string;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          periodType: "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
+          presentedOfferingId?: string;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId: string;
+          purchasedAtMs: number;
+          refundedAtMs?: number;
+          renewalNumber?: number;
+          store:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          taxPercentage?: number;
+          transactionId: string;
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        },
+        Name
+      >;
+      getByUser: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          autoRenewStatus?: boolean;
+          autoResumeAtMs?: number;
+          billingIssueDetectedAt?: number;
+          cancelReason?: string;
+          commissionPercentage?: number;
+          countryCode?: string;
+          currency?: string;
+          entitlementIds?: Array<string>;
+          environment: "SANDBOX" | "PRODUCTION";
+          expirationAtMs?: number;
+          expirationReason?: string;
+          gracePeriodExpirationAtMs?: number;
+          isFamilyShare: boolean;
+          isTrialConversion?: boolean;
+          kind?: "subscription" | "consumable";
+          newProductId?: string;
+          offerCode?: string;
+          originalPurchasedAtMs?: number;
+          originalTransactionId: string;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          periodType: "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
+          presentedOfferingId?: string;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId: string;
+          purchasedAtMs: number;
+          refundedAtMs?: number;
+          renewalNumber?: number;
+          store:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          taxPercentage?: number;
+          transactionId: string;
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      getConsumables: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          autoRenewStatus?: boolean;
+          autoResumeAtMs?: number;
+          billingIssueDetectedAt?: number;
+          cancelReason?: string;
+          commissionPercentage?: number;
+          countryCode?: string;
+          currency?: string;
+          entitlementIds?: Array<string>;
+          environment: "SANDBOX" | "PRODUCTION";
+          expirationAtMs?: number;
+          expirationReason?: string;
+          gracePeriodExpirationAtMs?: number;
+          isFamilyShare: boolean;
+          isTrialConversion?: boolean;
+          kind?: "subscription" | "consumable";
+          newProductId?: string;
+          offerCode?: string;
+          originalPurchasedAtMs?: number;
+          originalTransactionId: string;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          periodType: "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
+          presentedOfferingId?: string;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId: string;
+          purchasedAtMs: number;
+          refundedAtMs?: number;
+          renewalNumber?: number;
+          store:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          taxPercentage?: number;
+          transactionId: string;
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      getInGracePeriod: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          autoRenewStatus?: boolean;
+          autoResumeAtMs?: number;
+          billingIssueDetectedAt?: number;
+          cancelReason?: string;
+          commissionPercentage?: number;
+          countryCode?: string;
+          currency?: string;
+          entitlementIds?: Array<string>;
+          environment: "SANDBOX" | "PRODUCTION";
+          expirationAtMs?: number;
+          expirationReason?: string;
+          gracePeriodExpirationAtMs?: number;
+          isFamilyShare: boolean;
+          isTrialConversion?: boolean;
+          kind?: "subscription" | "consumable";
+          newProductId?: string;
+          offerCode?: string;
+          originalPurchasedAtMs?: number;
+          originalTransactionId: string;
+          ownershipType?: "PURCHASED" | "FAMILY_SHARED" | "UNKNOWN";
+          periodType: "TRIAL" | "INTRO" | "NORMAL" | "PROMOTIONAL" | "PREPAID";
+          presentedOfferingId?: string;
+          priceInPurchasedCurrency?: number;
+          priceUsd?: number;
+          productId: string;
+          purchasedAtMs: number;
+          refundedAtMs?: number;
+          renewalNumber?: number;
+          store:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+          taxPercentage?: number;
+          transactionId: string;
+          unsubscribeDetectedAt?: number;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      isInGracePeriod: FunctionReference<
+        "query",
+        "internal",
+        { originalTransactionId: string },
+        {
+          billingIssueDetectedAt?: number;
+          gracePeriodExpiresAt?: number;
+          inGracePeriod: boolean;
+        },
+        Name
+      >;
+    };
+    sync: {
+      ingest: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          appUserId: string;
+          hooks?: {
+            onEntitlementActivated?: string;
+            onEntitlementDeactivated?: string;
+          };
+          subscriber: any;
+        },
+        {
+          entitlements: number;
+          nonSubscriptions: number;
+          subscriptions: number;
+        },
+        Name
+      >;
+    };
+    transfers: {
+      backfillTransferParticipants: FunctionReference<
+        "mutation",
+        "internal",
+        { cursor?: string; pageSize?: number },
+        { nextCursor: string | null; scanned: number; written: number },
+        Name
+      >;
+      getByEventId: FunctionReference<
+        "query",
+        "internal",
+        { eventId: string },
+        {
+          _creationTime: number;
+          _id: string;
+          entitlementIds?: Array<string>;
+          eventId: string;
+          timestamp: number;
+          transferredFrom: Array<string>;
+          transferredTo: Array<string>;
+        } | null,
+        Name
+      >;
+      list: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          entitlementIds?: Array<string>;
+          eventId: string;
+          timestamp: number;
+          transferredFrom: Array<string>;
+          transferredTo: Array<string>;
+        }>,
+        Name
+      >;
+    };
+    virtualCurrency: {
+      getBalance: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string; currencyCode: string },
+        {
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          balance: number;
+          currencyCode: string;
+          currencyName: string;
+          updatedAt: number;
+        } | null,
+        Name
+      >;
+      listBalances: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appUserId: string;
+          balance: number;
+          currencyCode: string;
+          currencyName: string;
+          updatedAt: number;
+        }>,
+        Name
+      >;
+      listTransactions: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string; currencyCode?: string },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          amount: number;
+          appUserId: string;
+          currencyCode: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          productId?: string;
+          source?: string;
+          timestamp: number;
+          transactionId: string;
+        }>,
+        Name
+      >;
+    };
+    webhookEvents: {
+      getByEventId: FunctionReference<
+        "query",
+        "internal",
+        { eventId: string },
+        null | {
+          _creationTime: number;
+          _id: string;
+          appId?: string;
+          appUserId?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          error?: string;
+          eventId: string;
+          eventType: string;
+          payload: any;
+          processedAt: number;
+          status: "processed" | "failed" | "ignored";
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        },
+        Name
+      >;
+      listByType: FunctionReference<
+        "query",
+        "internal",
+        { eventType: string; limit?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appId?: string;
+          appUserId?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          error?: string;
+          eventId: string;
+          eventType: string;
+          payload: any;
+          processedAt: number;
+          status: "processed" | "failed" | "ignored";
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        }>,
+        Name
+      >;
+      listByUser: FunctionReference<
+        "query",
+        "internal",
+        { appUserId: string; limit?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appId?: string;
+          appUserId?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          error?: string;
+          eventId: string;
+          eventType: string;
+          payload: any;
+          processedAt: number;
+          status: "processed" | "failed" | "ignored";
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        }>,
+        Name
+      >;
+      listFailed: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          appId?: string;
+          appUserId?: string;
+          environment: "SANDBOX" | "PRODUCTION";
+          error?: string;
+          eventId: string;
+          eventType: string;
+          payload: any;
+          processedAt: number;
+          status: "processed" | "failed" | "ignored";
+          store?:
+            | "AMAZON"
+            | "APP_STORE"
+            | "MAC_APP_STORE"
+            | "GALAXY"
+            | "PADDLE"
+            | "PLAY_STORE"
+            | "PROMOTIONAL"
+            | "RC_BILLING"
+            | "ROKU"
+            | "STRIPE"
+            | "TEST_STORE"
+            | "EXTERNAL"
+            | "UNKNOWN_STORE";
+        }>,
+        Name
+      >;
+    };
+    webhooks: {
+      process: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          event: {
+            app_id?: string;
+            app_user_id?: string;
+            environment: "SANDBOX" | "PRODUCTION";
+            id: string;
+            store?:
+              | "AMAZON"
+              | "APP_STORE"
+              | "MAC_APP_STORE"
+              | "GALAXY"
+              | "PADDLE"
+              | "PLAY_STORE"
+              | "PROMOTIONAL"
+              | "RC_BILLING"
+              | "ROKU"
+              | "STRIPE"
+              | "TEST_STORE"
+              | "EXTERNAL"
+              | "UNKNOWN_STORE";
+            type: string;
+          };
+          hooks?: {
+            onEntitlementActivated?: string;
+            onEntitlementDeactivated?: string;
+          };
+          payload: any;
+        },
+        { eventId: string; processed: boolean },
+        Name
+      >;
+      recordFailure: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          error: string;
+          event: {
+            app_id?: string;
+            app_user_id?: string;
+            environment: "SANDBOX" | "PRODUCTION";
+            id: string;
+            store?:
+              | "AMAZON"
+              | "APP_STORE"
+              | "MAC_APP_STORE"
+              | "GALAXY"
+              | "PADDLE"
+              | "PLAY_STORE"
+              | "PROMOTIONAL"
+              | "RC_BILLING"
+              | "ROKU"
+              | "STRIPE"
+              | "TEST_STORE"
+              | "EXTERNAL"
+              | "UNKNOWN_STORE";
+            type: string;
+          };
+          payload: any;
+        },
+        null,
+        Name
+      >;
+    };
   };
-  entitlements: {
-    check: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string; entitlementId: string },
-      boolean,
-      Name
-    >;
-    list: FunctionReference<"query", "public", { appUserId: string }, EntitlementDoc[], Name>;
-    getActive: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      EntitlementDoc[],
-      Name
-    >;
-  };
-  subscriptions: {
-    getByUser: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      SubscriptionDoc[],
-      Name
-    >;
-    getActive: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      SubscriptionDoc[],
-      Name
-    >;
-    getConsumables: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      SubscriptionDoc[],
-      Name
-    >;
-    backfillKind: FunctionReference<
-      "mutation",
-      "internal",
-      { cursor?: string; pageSize?: number },
-      { scanned: number; written: number; nextCursor: string | null },
-      Name
-    >;
-    getByOriginalTransaction: FunctionReference<
-      "query",
-      "internal",
-      { originalTransactionId: string },
-      SubscriptionDoc | null,
-      Name
-    >;
-    isInGracePeriod: FunctionReference<
-      "query",
-      "internal",
-      { originalTransactionId: string },
-      GracePeriodStatus,
-      Name
-    >;
-    getInGracePeriod: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      SubscriptionDoc[],
-      Name
-    >;
-  };
-  sync: {
-    ingest: FunctionReference<
-      "mutation",
-      "public",
-      {
-        appUserId: string;
-        subscriber: {
-          entitlements?: any;
-          subscriptions?: any;
-          non_subscriptions?: any;
-          subscriber_attributes?: any;
-          first_seen?: string;
-          last_seen?: string;
-          original_app_user_id?: string;
-        };
-        hooks?: {
-          onEntitlementActivated?: string;
-          onEntitlementDeactivated?: string;
-        };
-      },
-      { subscriptions: number; entitlements: number; nonSubscriptions: number },
-      Name
-    >;
-  };
-  webhooks: {
-    process: FunctionReference<
-      "mutation",
-      "internal",
-      {
-        event: {
-          id: string;
-          type: string;
-          app_id?: string;
-          app_user_id?: string;
-          environment: Environment;
-          store?: Store;
-        };
-        payload: any;
-        hooks?: {
-          onEntitlementActivated?: string;
-          onEntitlementDeactivated?: string;
-        };
-      },
-      { processed: boolean; eventId: string },
-      Name
-    >;
-    checkRateLimit: FunctionReference<
-      "mutation",
-      "internal",
-      { key: string },
-      { allowed: boolean; remaining: number; resetAt: number },
-      Name
-    >;
-    recordFailure: FunctionReference<
-      "mutation",
-      "internal",
-      {
-        event: {
-          id: string;
-          type: string;
-          app_id?: string;
-          app_user_id?: string;
-          environment: Environment;
-          store?: Store;
-        };
-        payload: any;
-        error: string;
-      },
-      null,
-      Name
-    >;
-  };
-  experiments: {
-    list: FunctionReference<"query", "public", { appUserId: string }, ExperimentDoc[], Name>;
-    get: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string; experimentId: string },
-      ExperimentDoc | null,
-      Name
-    >;
-    listByExperiment: FunctionReference<
-      "query",
-      "internal",
-      { experimentId: string },
-      ExperimentDoc[],
-      Name
-    >;
-  };
-  webhookEvents: {
-    getByEventId: FunctionReference<
-      "query",
-      "internal",
-      { eventId: string },
-      WebhookEventDoc | null,
-      Name
-    >;
-    listByUser: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string; limit?: number },
-      WebhookEventDoc[],
-      Name
-    >;
-    listByType: FunctionReference<
-      "query",
-      "internal",
-      { eventType: string; limit?: number },
-      WebhookEventDoc[],
-      Name
-    >;
-    listFailed: FunctionReference<"query", "public", { limit?: number }, WebhookEventDoc[], Name>;
-  };
-  transfers: {
-    getByEventId: FunctionReference<
-      "query",
-      "internal",
-      { eventId: string },
-      TransferDoc | null,
-      Name
-    >;
-    list: FunctionReference<"query", "public", { limit?: number }, TransferDoc[], Name>;
-    backfillTransferParticipants: FunctionReference<
-      "mutation",
-      "public",
-      { cursor?: string; pageSize?: number },
-      { scanned: number; written: number; nextCursor: string | null },
-      Name
-    >;
-  };
-  invoices: {
-    get: FunctionReference<"query", "public", { invoiceId: string }, InvoiceDoc | null, Name>;
-    listByUser: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      InvoiceDoc[],
-      Name
-    >;
-  };
-  virtualCurrency: {
-    getBalance: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string; currencyCode: string },
-      VirtualCurrencyBalanceDoc | null,
-      Name
-    >;
-    listBalances: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string },
-      VirtualCurrencyBalanceDoc[],
-      Name
-    >;
-    listTransactions: FunctionReference<
-      "query",
-      "internal",
-      { appUserId: string; currencyCode?: string },
-      VirtualCurrencyTransactionDoc[],
-      Name
-    >;
-  };
-};

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -107,11 +107,6 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
 
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
-
 /**
  * A set of services for use within Convex query functions.
  *

--- a/src/component/audit-fixes.test.ts
+++ b/src/component/audit-fixes.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, test } from "vitest";
 import { ConvexError } from "convex/values";
 import { api, internal } from "./_generated/api.js";
 import { initConvexTest } from "./setup.test.js";
+import type { ComponentApi } from "./_generated/component.js";
+
+// The secret-validation tests below probe the RevenueCat constructor, not the
+// component, so the component shape is irrelevant. A typed stub keeps them
+// prettier-proof (no @ts-expect-error directive to misalign).
+const stubComponent = {} as unknown as ComponentApi;
 
 function basePayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -32,13 +38,14 @@ async function postEvent(
   t: ReturnType<typeof initConvexTest>,
   payload: Record<string, unknown>,
 ) {
-  return t.mutation(internal.webhooks.process, {
+  return t.mutation(api.webhooks.process, {
     event: {
       id: payload.id as string,
       type: payload.type as string,
       app_id: payload.app_id as string | undefined,
       app_user_id: payload.app_user_id as string | undefined,
-      environment: (payload.environment as "SANDBOX" | "PRODUCTION") ?? "SANDBOX",
+      environment:
+        (payload.environment as "SANDBOX" | "PRODUCTION") ?? "SANDBOX",
       store: payload.store as
         | "AMAZON"
         | "APP_STORE"
@@ -195,86 +202,80 @@ describe("audit fixes", () => {
 
     test("RevenueCat class rejects empty auth secret", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Intentionally probing with a stub component
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: "" })).toThrow(
+      expect(() => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: "" })).toThrow(
         /is empty after stripping/,
       );
     });
 
     test("RevenueCat class rejects 'Bearer ' (paste error: header label only)", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: "Bearer " })).toThrow(
-        /is empty after stripping/,
-      );
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: "Bearer " }),
+      ).toThrow(/is empty after stripping/);
     });
 
     test("RevenueCat class rejects whitespace-only secret", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: "    " })).toThrow(
-        /is empty after stripping/,
-      );
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: "    " }),
+      ).toThrow(/is empty after stripping/);
     });
 
     test("RevenueCat class rejects sub-32-char secret", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: "s3cret" })).toThrow(
-        /is 6 chars after stripping \(minimum 32\)/,
-      );
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: "s3cret" }),
+      ).toThrow(/is 6 chars after stripping \(minimum 32\)/);
     });
 
     test("RevenueCat class rejects 31-char secret (just under floor)", async () => {
       const { RevenueCat } = await import("../client/index.js");
       const justUnder = "a".repeat(31);
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: justUnder })).toThrow(
-        /is 31 chars after stripping \(minimum 32\)/,
-      );
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: justUnder }),
+      ).toThrow(/is 31 chars after stripping \(minimum 32\)/);
     });
 
     test("RevenueCat class rejects short secret hidden behind 'Bearer ' prefix", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: "Bearer s3cret" })).toThrow(
-        /is 6 chars after stripping \(minimum 32\)/,
-      );
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: "Bearer s3cret" }),
+      ).toThrow(/is 6 chars after stripping \(minimum 32\)/);
     });
 
     test("RevenueCat class accepts undefined auth for non-webhook usage", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, {})).not.toThrow();
+      expect(() => new RevenueCat(stubComponent, {})).not.toThrow();
     });
 
     test("RevenueCat class accepts a 32-char secret (at floor)", async () => {
       const { RevenueCat } = await import("../client/index.js");
       const atFloor = "a".repeat(32);
-      // @ts-expect-error: Stub component for construction test
-      expect(() => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: atFloor })).not.toThrow();
+      expect(
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: atFloor }),
+      ).not.toThrow();
     });
 
     test("RevenueCat class accepts a real openssl-style secret", async () => {
       const { RevenueCat } = await import("../client/index.js");
       expect(
-        // @ts-expect-error: Stub component for construction test
-        () => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: VALID_SECRET }),
+        () => new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: VALID_SECRET }),
       ).not.toThrow();
     });
 
     test("RevenueCat class accepts the same secret with a Bearer prefix", async () => {
       const { RevenueCat } = await import("../client/index.js");
       expect(
-        // @ts-expect-error: Stub component for construction test
-        () => new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: `Bearer ${VALID_SECRET}` }),
+        () =>
+          new RevenueCat(stubComponent,
+            { REVENUECAT_WEBHOOK_AUTH: `Bearer ${VALID_SECRET}` },
+          ),
       ).not.toThrow();
     });
 
     test("httpHandler() does not throw at build time when auth is undefined", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for handler-construction test
-      const rc = new RevenueCat({}, {});
+      const rc = new RevenueCat(stubComponent, {});
       // A build-time throw would fail Convex push analysis and block
       // component codegen for consumers. Validation moved to request time.
       expect(() => rc.httpHandler()).not.toThrow();
@@ -282,24 +283,30 @@ describe("audit fixes", () => {
 
     test("webhook handler rejects with 500 when auth is undefined", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for handler test
-      const rc = new RevenueCat({}, {});
+      const rc = new RevenueCat(stubComponent, {});
       const handler = rc.httpHandler() as unknown as {
         _handler: (ctx: unknown, request: Request) => Promise<Response>;
       };
-      const request = new Request("https://example.convex.site/webhooks/revenuecat", {
-        method: "POST",
-        headers: { Authorization: "Bearer anything", "Content-Type": "application/json" },
-        body: JSON.stringify({ event: { id: "evt_no_secret", type: "TEST" } }),
-      });
+      const request = new Request(
+        "https://example.convex.site/webhooks/revenuecat",
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer anything",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            event: { id: "evt_no_secret", type: "TEST" },
+          }),
+        },
+      );
       const res = await handler._handler({}, request);
       expect(res.status).toBe(500);
     });
 
     test("httpHandler() succeeds when a real secret is configured", async () => {
       const { RevenueCat } = await import("../client/index.js");
-      // @ts-expect-error: Stub component for handler-construction test
-      const rc = new RevenueCat({}, { REVENUECAT_WEBHOOK_AUTH: VALID_SECRET });
+      const rc = new RevenueCat(stubComponent, { REVENUECAT_WEBHOOK_AUTH: VALID_SECRET });
       expect(() => rc.httpHandler()).not.toThrow();
     });
   });
@@ -854,7 +861,9 @@ describe("audit fixes", () => {
         }),
       );
 
-      const customer = await t.query(api.customers.get, { appUserId: "user_lastseen" });
+      const customer = await t.query(api.customers.get, {
+        appUserId: "user_lastseen",
+      });
       expect(customer?.lastSeenAt).toBe(later);
     });
   });
@@ -879,7 +888,9 @@ describe("audit fixes", () => {
       partial.original_app_user_id = undefined as unknown as string;
       await postEvent(t, partial);
 
-      const customer = await t.query(api.customers.get, { appUserId: "user_canon" });
+      const customer = await t.query(api.customers.get, {
+        appUserId: "user_canon",
+      });
       expect(customer?.originalAppUserId).toBe(canonical);
     });
   });
@@ -950,7 +961,9 @@ describe("audit fixes", () => {
       await t.mutation(internal.handlers.processTransfer, { event: payload });
 
       const transfers = await t.query(api.transfers.list, {});
-      const sameEvent = transfers.filter((tr) => tr.eventId === "evt_transfer_dedup");
+      const sameEvent = transfers.filter(
+        (tr) => tr.eventId === "evt_transfer_dedup",
+      );
       expect(sameEvent.length).toBe(1);
     });
   });
@@ -1011,7 +1024,9 @@ describe("audit fixes", () => {
           transaction_id: "txn_consumable",
         }),
       );
-      const subs = await t.query(api.subscriptions.getByUser, { appUserId: subject });
+      const subs = await t.query(api.subscriptions.getByUser, {
+        appUserId: subject,
+      });
       expect(subs[0].kind).toBe("consumable");
     });
 
@@ -1028,7 +1043,9 @@ describe("audit fixes", () => {
           transaction_id: "txn_recurring",
         }),
       );
-      const subs = await t.query(api.subscriptions.getByUser, { appUserId: subject });
+      const subs = await t.query(api.subscriptions.getByUser, {
+        appUserId: subject,
+      });
       expect(subs[0].kind).toBe("subscription");
     });
 
@@ -1057,7 +1074,9 @@ describe("audit fixes", () => {
           transaction_id: "txn_mixed_b",
         }),
       );
-      const active = await t.query(api.subscriptions.getActive, { appUserId: subject });
+      const active = await t.query(api.subscriptions.getActive, {
+        appUserId: subject,
+      });
       expect(active.length).toBe(1);
       expect(active[0].productId).toBe("premium_monthly");
       const consumables = await t.query(api.subscriptions.getConsumables, {
@@ -1216,7 +1235,7 @@ describe("audit fixes", () => {
       // Direct invocation (unreachable from the wire) still throws.
       const t = initConvexTest();
       await expect(
-        t.mutation(internal.webhooks.process, {
+        t.mutation(api.webhooks.process, {
           event: {
             id: "   ",
             type: "INITIAL_PURCHASE",
@@ -1240,11 +1259,17 @@ describe("audit fixes", () => {
         });
       });
 
-      const first = await t.mutation(internal.transfers.backfillTransferParticipants, {});
+      const first = await t.mutation(
+        api.transfers.backfillTransferParticipants,
+        {},
+      );
       expect(first.written).toBe(2);
       expect(first.nextCursor).toBeNull();
 
-      const second = await t.mutation(internal.transfers.backfillTransferParticipants, {});
+      const second = await t.mutation(
+        api.transfers.backfillTransferParticipants,
+        {},
+      );
       expect(second.written).toBe(0);
 
       const participants = await t.run(async (ctx) => {
@@ -1297,18 +1322,20 @@ describe("audit fixes", () => {
         }
       });
 
-      const first = await t.mutation(internal.subscriptions.backfillKind, {});
+      const first = await t.mutation(api.subscriptions.backfillKind, {});
       expect(first.written).toBe(1);
       expect(first.nextCursor).toBeNull();
 
-      const subs = await t.query(api.subscriptions.getByUser, { appUserId: subject });
+      const subs = await t.query(api.subscriptions.getByUser, {
+        appUserId: subject,
+      });
       const consumable = subs.find((s) => s.originalTransactionId === txnA);
       const recurring = subs.find((s) => s.originalTransactionId === txnB);
       expect(consumable?.kind).toBe("consumable");
       expect(recurring?.kind).toBeUndefined();
 
       // Idempotent: a second run finds nothing to do.
-      const second = await t.mutation(internal.subscriptions.backfillKind, {});
+      const second = await t.mutation(api.subscriptions.backfillKind, {});
       expect(second.written).toBe(0);
     });
 
@@ -1337,12 +1364,16 @@ describe("audit fixes", () => {
           .first();
         if (sub) await ctx.db.patch(sub._id, { kind: undefined });
       });
-      const beforeActive = await t.query(api.subscriptions.getActive, { appUserId: subject });
+      const beforeActive = await t.query(api.subscriptions.getActive, {
+        appUserId: subject,
+      });
       expect(beforeActive.length).toBe(1);
 
-      await t.mutation(internal.subscriptions.backfillKind, {});
+      await t.mutation(api.subscriptions.backfillKind, {});
 
-      const afterActive = await t.query(api.subscriptions.getActive, { appUserId: subject });
+      const afterActive = await t.query(api.subscriptions.getActive, {
+        appUserId: subject,
+      });
       expect(afterActive.length).toBe(0);
       const afterConsumables = await t.query(api.subscriptions.getConsumables, {
         appUserId: subject,

--- a/src/component/customers.ts
+++ b/src/component/customers.ts
@@ -128,11 +128,16 @@ export const purge = mutation({
           .collect(),
       ),
     );
+    // TRANSFER webhookEvents are stored with appUserId undefined (RC TRANSFER
+    // events carry no app_user_id), so the by_app_user sweep above can't reach
+    // them. Collect the originating event ids to purge those audit rows too.
+    const transferEventIds = new Set<string>();
     for (let i = 0; i < transferIdList.length; i++) {
       const transfer = transferRows[i];
       if (!transfer) continue;
       await ctx.db.delete(transfer._id);
       counts.transfers++;
+      if (transfer.eventId) transferEventIds.add(transfer.eventId);
       await Promise.all(
         siblingsLists[i].map((sibling) => ctx.db.delete(sibling._id)),
       );
@@ -155,6 +160,7 @@ export const purge = mutation({
         await ctx.db.delete(transfer._id);
         counts.transfers++;
         legacyHits++;
+        if (transfer.eventId) transferEventIds.add(transfer.eventId);
       }
     }
     // Only throw if we hit the cap AND found unbackfilled hits, otherwise
@@ -164,6 +170,20 @@ export const purge = mutation({
         code: "PURGE_SAFETY_CAP_EXCEEDED",
         message: `purge incomplete: legacy transfers scan capped at ${PURGE_SAFETY_CAP} with hits for ${appUserId}; run backfillTransferParticipants then retry`,
       });
+    }
+
+    // Purge the TRANSFER audit rows correlated to the deleted transfers. Each
+    // transfer's eventId is the originating TRANSFER webhook's id (see
+    // processTransfer), and those webhookEvents have a null appUserId.
+    for (const eventId of transferEventIds) {
+      const auditRow = await ctx.db
+        .query("webhookEvents")
+        .withIndex("by_event_id", (q) => q.eq("eventId", eventId))
+        .first();
+      if (auditRow) {
+        await ctx.db.delete(auditRow._id);
+        counts.webhookEvents++;
+      }
     }
 
     const customer = await ctx.db

--- a/src/component/entitlements.ts
+++ b/src/component/entitlements.ts
@@ -18,6 +18,13 @@
  * `billingIssueDetectedAt` check). That historically leaked access
  * indefinitely if EXPIRATION was delayed or dropped. Mirror the iOS SDK's
  * `EntitlementInfo.isActive`: pure expiry-date comparison.
+ *
+ * `Date.now()` in these queries is deliberate: it keeps the expiry gate
+ * reactive in the window between true expiry and the EXPIRATION webhook that
+ * flips `isActive`. Convex re-runs time-dependent queries so they don't go
+ * stale (a query-cache cost, not a correctness bug); the per-user tables are
+ * tiny, so the cost is negligible. Do not replace it with a cron-maintained
+ * boolean, that trades correctness for cache hits.
  */
 import { v } from "convex/values";
 import { query } from "./_generated/server.js";

--- a/src/component/handlers.test.ts
+++ b/src/component/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { api, internal } from "./_generated/api.js";
+import { api } from "./_generated/api.js";
 import { initConvexTest } from "./setup.test.js";
 
 function createEventPayload(
@@ -15,7 +15,10 @@ function createEventPayload(
     expiration_reason: string;
     auto_resume_at_ms: number;
     transferred_from: string[];
-    subscriber_attributes: Record<string, { value: string; updated_at_ms: number }>;
+    subscriber_attributes: Record<
+      string,
+      { value: string; updated_at_ms: number }
+    >;
     experiments: Array<{
       experiment_id: string;
       experiment_variant: string;
@@ -30,16 +33,19 @@ function createEventPayload(
     id: overrides.id ?? `evt_${Date.now()}`,
     app_id: "app_123",
     app_user_id: overrides.app_user_id ?? "user_123",
-    original_app_user_id: overrides.original_app_user_id ?? overrides.app_user_id ?? "user_123",
+    original_app_user_id:
+      overrides.original_app_user_id ?? overrides.app_user_id ?? "user_123",
     aliases: [],
     event_timestamp_ms: Date.now(),
     product_id: overrides.product_id ?? "premium_monthly",
     entitlement_ids: overrides.entitlement_ids ?? ["premium"],
     period_type: "NORMAL" as const,
     purchased_at_ms: Date.now(),
-    expiration_at_ms: overrides.expiration_at_ms ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
+    expiration_at_ms:
+      overrides.expiration_at_ms ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
     transaction_id: overrides.transaction_id ?? `txn_${Date.now()}`,
-    original_transaction_id: overrides.original_transaction_id ?? `txn_original_${Date.now()}`,
+    original_transaction_id:
+      overrides.original_transaction_id ?? `txn_original_${Date.now()}`,
     store: "APP_STORE" as const,
     environment: "SANDBOX" as const,
     is_family_share: false,
@@ -63,7 +69,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium", "pro"],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -96,7 +102,7 @@ describe("handlers", () => {
         app_user_id: "user_initial_2",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -128,7 +134,7 @@ describe("handlers", () => {
         is_family_share: undefined,
         ownership_type: "FAMILY_SHARED",
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -158,7 +164,7 @@ describe("handlers", () => {
         }),
         ownership_type: "FAMILY_SHARED",
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -185,7 +191,7 @@ describe("handlers", () => {
         product_id: "premium_yearly",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -218,7 +224,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -238,7 +244,7 @@ describe("handlers", () => {
         cancel_reason: "UNSUBSCRIBE",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -268,7 +274,7 @@ describe("handlers", () => {
         app_user_id: "user_cancel_refund",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -296,7 +302,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
         cancel_reason: "CUSTOMER_SUPPORT",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -332,7 +338,7 @@ describe("handlers", () => {
         type: "INITIAL_PURCHASE",
         app_user_id: "user_cancel_exp",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -352,7 +358,7 @@ describe("handlers", () => {
         }),
         experiments: experimentsArr,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -382,7 +388,7 @@ describe("handlers", () => {
         app_user_id: "user_refund_ts",
         original_transaction_id: "txn_refund_ts",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -403,7 +409,7 @@ describe("handlers", () => {
         }),
         event_timestamp_ms: refundTime,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -429,7 +435,7 @@ describe("handlers", () => {
         app_user_id: "user_nrefund",
         original_transaction_id: "txn_nrefund",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -447,7 +453,7 @@ describe("handlers", () => {
         original_transaction_id: "txn_nrefund",
         cancel_reason: "UNSUBSCRIBE",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -474,7 +480,7 @@ describe("handlers", () => {
         app_user_id: "user_cancel_negprice",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -497,7 +503,7 @@ describe("handlers", () => {
         }),
         price: -9.99,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -526,7 +532,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -546,7 +552,7 @@ describe("handlers", () => {
         }),
         entitlement_ids: undefined,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -578,7 +584,7 @@ describe("handlers", () => {
         expiration_at_ms: Date.now() + 1000,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -604,7 +610,7 @@ describe("handlers", () => {
         expiration_reason: "SUBSCRIPTION_EXPIRED",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -644,8 +650,15 @@ describe("handlers", () => {
       });
 
       for (const p of [premiumPayload, proPayload]) {
-        await t.mutation(internal.webhooks.process, {
-          event: { id: p.id, type: p.type, app_id: p.app_id, app_user_id: p.app_user_id, environment: p.environment, store: p.store },
+        await t.mutation(api.webhooks.process, {
+          event: {
+            id: p.id,
+            type: p.type,
+            app_id: p.app_id,
+            app_user_id: p.app_user_id,
+            environment: p.environment,
+            store: p.store,
+          },
           payload: p,
         });
       }
@@ -661,14 +674,31 @@ describe("handlers", () => {
         entitlement_ids: undefined,
       };
 
-      await t.mutation(internal.webhooks.process, {
-        event: { id: expirePayload.id, type: expirePayload.type, app_id: expirePayload.app_id, app_user_id: expirePayload.app_user_id, environment: expirePayload.environment, store: expirePayload.store },
+      await t.mutation(api.webhooks.process, {
+        event: {
+          id: expirePayload.id,
+          type: expirePayload.type,
+          app_id: expirePayload.app_id,
+          app_user_id: expirePayload.app_user_id,
+          environment: expirePayload.environment,
+          store: expirePayload.store,
+        },
         payload: expirePayload,
       });
 
       // Both entitlements should still be active, neither was targeted
-      expect(await t.query(api.entitlements.check, { appUserId: "user_expire_guard", entitlementId: "premium" })).toBe(true);
-      expect(await t.query(api.entitlements.check, { appUserId: "user_expire_guard", entitlementId: "pro" })).toBe(true);
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: "user_expire_guard",
+          entitlementId: "premium",
+        }),
+      ).toBe(true);
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: "user_expire_guard",
+          entitlementId: "pro",
+        }),
+      ).toBe(true);
     });
   });
 
@@ -685,7 +715,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -705,7 +735,7 @@ describe("handlers", () => {
         auto_resume_at_ms: futureResume,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: pausePayload.id,
           type: pausePayload.type,
@@ -739,7 +769,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -769,7 +799,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: transferPayload.id,
           type: transferPayload.type,
@@ -808,7 +838,7 @@ describe("handlers", () => {
         expiration_at_ms: newerExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: sourcePayload.id,
           type: sourcePayload.type,
@@ -828,7 +858,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: destPayload.id,
           type: destPayload.type,
@@ -852,7 +882,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: transferPayload.id,
           type: transferPayload.type,
@@ -895,7 +925,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -917,7 +947,7 @@ describe("handlers", () => {
         grace_period_expiration_at_ms: gracePeriodExpiration,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -968,7 +998,7 @@ describe("handlers", () => {
         }),
         grace_period_expiration_at_ms: Date.now() + 7 * 24 * 60 * 60 * 1000,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -995,7 +1025,7 @@ describe("handlers", () => {
         app_user_id: "user_billing_ceiling",
         expiration_at_ms: Date.now() + 1000, // soon-to-expire
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1015,7 +1045,7 @@ describe("handlers", () => {
         }),
         grace_period_expiration_at_ms: gracePeriodEnd,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -1055,7 +1085,7 @@ describe("handlers", () => {
         expiration_at_ms: initialExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1074,7 +1104,7 @@ describe("handlers", () => {
         expiration_at_ms: renewedExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: renewPayload.id,
           type: renewPayload.type,
@@ -1114,12 +1144,24 @@ describe("handlers", () => {
         expiration_at_ms: renewedExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
-        event: { id: renewPayload.id, type: renewPayload.type, app_id: renewPayload.app_id, app_user_id: renewPayload.app_user_id, environment: renewPayload.environment, store: renewPayload.store },
+      await t.mutation(api.webhooks.process, {
+        event: {
+          id: renewPayload.id,
+          type: renewPayload.type,
+          app_id: renewPayload.app_id,
+          app_user_id: renewPayload.app_user_id,
+          environment: renewPayload.environment,
+          store: renewPayload.store,
+        },
         payload: renewPayload,
       });
 
-      expect(await t.query(api.entitlements.check, { appUserId: "user_renew_missing", entitlementId: "premium" })).toBe(true);
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: "user_renew_missing",
+          entitlementId: "premium",
+        }),
+      ).toBe(true);
     });
   });
 
@@ -1140,7 +1182,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1164,7 +1206,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -1193,7 +1235,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: uncancelPayload.id,
           type: uncancelPayload.type,
@@ -1232,7 +1274,7 @@ describe("handlers", () => {
         expiration_at_ms: initialExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1251,7 +1293,7 @@ describe("handlers", () => {
         expiration_at_ms: extendedExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: extendPayload.id,
           type: extendPayload.type,
@@ -1291,7 +1333,7 @@ describe("handlers", () => {
         transaction_id: sharedTransactionId,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1316,7 +1358,7 @@ describe("handlers", () => {
         new_product_id: "yearly_premium",
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: changePayload.id,
           type: changePayload.type,
@@ -1357,7 +1399,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1403,7 +1445,7 @@ describe("handlers", () => {
         expiration_at_ms: tempExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1443,7 +1485,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1463,7 +1505,7 @@ describe("handlers", () => {
         expiration_reason: "CUSTOMER_SUPPORT",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -1488,7 +1530,7 @@ describe("handlers", () => {
         expiration_at_ms: futureExpiration,
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundReversedPayload.id,
           type: refundReversedPayload.type,
@@ -1519,7 +1561,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1546,7 +1588,7 @@ describe("handlers", () => {
         store: "RC_BILLING" as const,
       };
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1572,12 +1614,14 @@ describe("handlers", () => {
         app_user_id: "user_vcurrency_1",
         environment: "PRODUCTION" as const,
         store: "APP_STORE" as const,
-        adjustments: [{ amount: 100, currency: { code: "coins", name: "Coins" } }],
+        adjustments: [
+          { amount: 100, currency: { code: "coins", name: "Coins" } },
+        ],
         virtual_currency_transaction_id: "vct_123",
         source: "in_app_purchase",
       };
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1609,8 +1653,14 @@ describe("handlers", () => {
         source: "in_app_purchase",
       };
 
-      await t.mutation(internal.webhooks.process, {
-        event: { id: payload.id, type: payload.type, app_user_id: payload.app_user_id, environment: payload.environment, store: payload.store },
+      await t.mutation(api.webhooks.process, {
+        event: {
+          id: payload.id,
+          type: payload.type,
+          app_user_id: payload.app_user_id,
+          environment: payload.environment,
+          store: payload.store,
+        },
         payload,
       });
 
@@ -1632,7 +1682,10 @@ describe("handlers", () => {
 
       // Both currency adjustments must have their own transaction record
       expect(transactions.length).toBe(2);
-      expect(transactions.map((tx) => tx.currencyCode).sort()).toEqual(["coins", "gems"]);
+      expect(transactions.map((tx) => tx.currencyCode).sort()).toEqual([
+        "coins",
+        "gems",
+      ]);
     });
   });
 
@@ -1652,7 +1705,7 @@ describe("handlers", () => {
         experiment_enrolled_at_ms: Date.now(),
       };
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1681,7 +1734,7 @@ describe("handlers", () => {
         experiment_enrolled_at_ms: enrolledAt,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1721,7 +1774,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload1.id,
           type: payload1.type,
@@ -1752,7 +1805,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload2.id,
           type: payload2.type,
@@ -1793,7 +1846,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1811,7 +1864,9 @@ describe("handlers", () => {
 
       expect(customer).not.toBeNull();
       expect(customer?.attributes).toBeDefined();
-      expect(customer?.attributes?.__dollar__email?.value).toBe("test@example.com");
+      expect(customer?.attributes?.__dollar__email?.value).toBe(
+        "test@example.com",
+      );
       expect(customer?.attributes?.custom_plan?.value).toBe("enterprise");
     });
 
@@ -1836,7 +1891,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload1.id,
           type: payload1.type,
@@ -1864,7 +1919,7 @@ describe("handlers", () => {
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload2.id,
           type: payload2.type,
@@ -1880,7 +1935,9 @@ describe("handlers", () => {
         appUserId: "user_attrs_merge",
       });
 
-      expect(customer?.attributes?.__dollar__email?.value).toBe("new@example.com"); // newer
+      expect(customer?.attributes?.__dollar__email?.value).toBe(
+        "new@example.com",
+      ); // newer
       expect(customer?.attributes?.plan?.value).toBe("starter"); // older kept
     });
   });
@@ -1903,7 +1960,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1943,7 +2000,7 @@ describe("handlers", () => {
         ],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -1976,7 +2033,7 @@ describe("handlers", () => {
         app_user_id: "user_alias_test",
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: initialPayload.id,
           type: initialPayload.type,
@@ -1997,7 +2054,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2031,7 +2088,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2062,7 +2119,7 @@ describe("handlers", () => {
         environment: "SANDBOX" as const,
       };
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2112,7 +2169,7 @@ describe("handlers", () => {
         original_app_user_id: realUserId,
         expiration_at_ms: now + 10 * 24 * 60 * 60 * 1000, // +10 days
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: realPurchase.id,
           type: realPurchase.type,
@@ -2131,7 +2188,7 @@ describe("handlers", () => {
         original_app_user_id: anonymousId,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000, // +30 days (newer)
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: anonPurchase.id,
           type: anonPurchase.type,
@@ -2150,7 +2207,7 @@ describe("handlers", () => {
         original_app_user_id: anonymousId,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: billingPayload.id,
           type: billingPayload.type,
@@ -2162,10 +2219,14 @@ describe("handlers", () => {
       });
 
       // Confirm the anonymous entitlement has billingIssueDetectedAt set
-      const anonEnts = await t.query(api.entitlements.list, { appUserId: anonymousId });
+      const anonEnts = await t.query(api.entitlements.list, {
+        appUserId: anonymousId,
+      });
       expect(anonEnts[0].billingIssueDetectedAt).toBeDefined();
       // And the real user's entitlement does NOT yet have it
-      const realEntsBefore = await t.query(api.entitlements.list, { appUserId: realUserId });
+      const realEntsBefore = await t.query(api.entitlements.list, {
+        appUserId: realUserId,
+      });
       expect(realEntsBefore[0].billingIssueDetectedAt).toBeUndefined();
 
       // User logs in, SUBSCRIBER_ALIAS merges anonymous (newer) → real (existing, older)
@@ -2179,7 +2240,7 @@ describe("handlers", () => {
         aliases: [anonymousId],
         environment: "SANDBOX" as const,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2191,7 +2252,9 @@ describe("handlers", () => {
 
       // billingIssueDetectedAt from the anonymous (source) record must be carried
       // over to the real user's entitlement, without it they'd lose grace-period access.
-      const realEnts = await t.query(api.entitlements.list, { appUserId: realUserId });
+      const realEnts = await t.query(api.entitlements.list, {
+        appUserId: realUserId,
+      });
       expect(realEnts.length).toBe(1);
       expect(realEnts[0].billingIssueDetectedAt).toBeDefined();
     });
@@ -2235,9 +2298,13 @@ describe("handlers", () => {
       });
 
       // Confirm state before alias: anon has it, real doesn't
-      const anonEnts = await t.query(api.entitlements.list, { appUserId: anonymousId });
+      const anonEnts = await t.query(api.entitlements.list, {
+        appUserId: anonymousId,
+      });
       expect(anonEnts[0].unsubscribeDetectedAt).toBe(unsubscribeTs);
-      const realEntsBefore = await t.query(api.entitlements.list, { appUserId: realUserId });
+      const realEntsBefore = await t.query(api.entitlements.list, {
+        appUserId: realUserId,
+      });
       expect(realEntsBefore[0].unsubscribeDetectedAt).toBeUndefined();
 
       // SUBSCRIBER_ALIAS: anon (newer) → real (existing, older)
@@ -2250,7 +2317,7 @@ describe("handlers", () => {
         aliases: [anonymousId],
         environment: "SANDBOX" as const,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: aliasPayload.id,
           type: aliasPayload.type,
@@ -2261,7 +2328,9 @@ describe("handlers", () => {
       });
 
       // unsubscribeDetectedAt from source must survive the merge
-      const realEnts = await t.query(api.entitlements.list, { appUserId: realUserId });
+      const realEnts = await t.query(api.entitlements.list, {
+        appUserId: realUserId,
+      });
       expect(realEnts.length).toBe(1);
       expect(realEnts[0].unsubscribeDetectedAt).toBe(unsubscribeTs);
     });
@@ -2279,7 +2348,7 @@ describe("handlers", () => {
         app_user_id: "user_refund_1",
         expiration_at_ms: futureExpiration,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2292,7 +2361,10 @@ describe("handlers", () => {
       });
 
       expect(
-        await t.query(api.entitlements.check, { appUserId: "user_refund_1", entitlementId: "premium" }),
+        await t.query(api.entitlements.check, {
+          appUserId: "user_refund_1",
+          entitlementId: "premium",
+        }),
       ).toBe(true);
 
       // Refund issued, should revoke entitlement immediately
@@ -2303,7 +2375,7 @@ describe("handlers", () => {
         expiration_at_ms: Date.now() - 1000,
         expiration_reason: "CUSTOMER_SUPPORT",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -2316,7 +2388,10 @@ describe("handlers", () => {
       });
 
       expect(
-        await t.query(api.entitlements.check, { appUserId: "user_refund_1", entitlementId: "premium" }),
+        await t.query(api.entitlements.check, {
+          appUserId: "user_refund_1",
+          entitlementId: "premium",
+        }),
       ).toBe(false);
     });
 
@@ -2331,7 +2406,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 30 * 24 * 60 * 60 * 1000,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: purchasePayload.id,
           type: purchasePayload.type,
@@ -2352,7 +2427,7 @@ describe("handlers", () => {
         }),
         entitlement_ids: undefined,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: refundPayload.id,
           type: refundPayload.type,
@@ -2365,7 +2440,10 @@ describe("handlers", () => {
 
       // Entitlement should still be active, unmapped product refund shouldn't revoke
       expect(
-        await t.query(api.entitlements.check, { appUserId: "user_refund_multi", entitlementId: "premium" }),
+        await t.query(api.entitlements.check, {
+          appUserId: "user_refund_multi",
+          entitlementId: "premium",
+        }),
       ).toBe(true);
     });
   });
@@ -2416,7 +2494,7 @@ describe("handlers", () => {
         entitlement_ids: ["premium"],
         expiration_at_ms: Date.now() + 60 * 86400000,
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,

--- a/src/component/handlers.ts
+++ b/src/component/handlers.ts
@@ -181,6 +181,11 @@ const eventPayloadValidator = v.object({
   ),
   virtual_currency_transaction_id: v.optional(v.string()),
   source: v.optional(v.string()),
+  // PURCHASE_REDEEMED (Web Billing code redemption).
+  redeemed_from: v.optional(v.array(v.string())),
+  redeemed_by: v.optional(v.array(v.string())),
+  redemption_outcome: v.optional(v.string()),
+  redemption_platform: v.optional(v.string()),
   metadata: v.optional(v.any()),
   product_display_name: v.optional(v.string()),
   purchase_environment: v.optional(environmentValidator),
@@ -386,6 +391,8 @@ async function upsertSubscription(
         : (existing?.isFamilyShare ?? false),
     ownershipType,
     isTrialConversion: event.is_trial_conversion ?? existing?.isTrialConversion,
+    // RC `price` is already USD-normalized ("The USD price of the transaction");
+    // `priceInPurchasedCurrency` holds the charged-currency amount.
     priceUsd: event.price ?? existing?.priceUsd,
     currency: event.currency ?? existing?.currency,
     priceInPurchasedCurrency:
@@ -736,8 +743,13 @@ export const processCancellation = internalMutation({
     if (event.cancel_reason === "UNSUBSCRIBE") {
       overrides.unsubscribeDetectedAt = event.event_timestamp_ms;
     }
-    // BILLING_ERROR cancel = retry exhaustion. Mirror BILLING_ISSUE so
-    // willRenew/grace-period queries return the right state.
+    // BILLING_ERROR cancel = retry exhaustion. Set the billing-issue marker so
+    // willRenew goes false. Grace EXTENSION (pushing entitlement expiry to
+    // grace-end) is deliberately NOT done here: grace_period_expiration_at_ms
+    // rides only on the companion BILLING_ISSUE event RC sends alongside this
+    // one. Until it arrives the entitlement keeps its original expiry, denying
+    // grace access rather than risking a leak (see entitlements.ts: never gate
+    // on a bare billingIssueDetectedAt). EXPIRATION revokes at true grace-end.
     if (event.cancel_reason === "BILLING_ERROR") {
       overrides.billingIssueDetectedAt = event.event_timestamp_ms;
     }
@@ -1121,13 +1133,52 @@ export const processRefundReversed = internalMutation({
   handler: async (ctx, args) => {
     const event = args.event as EventPayload;
     await recordEvent(ctx, event);
-    // Reversal supersedes the refund, clear markers, re-enable auto-renew.
+    // Reversal supersedes the refund: clear refund markers, re-enable
+    // auto-renew. The `true` is AND-ed with the derived signal in
+    // upsertSubscription, so a prior unsubscribe or billing issue still wins;
+    // only an explicit `false` could force renewal off.
     await upsertSubscription(ctx, event, {
       refundedAtMs: undefined,
       cancelReason: undefined,
       autoRenewStatus: true,
     });
     await grantEntitlements(ctx, event);
+    return null;
+  },
+});
+
+export const processPurchaseRedeemed = internalMutation({
+  args: { event: v.any() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const event = args.event as EventPayload;
+    await recordEvent(ctx, event);
+    // PURCHASE_REDEEMED (Web Billing code redemption) carries NO top-level
+    // app_user_id: the redeemer is in `redeemed_by`, the original purchaser in
+    // `redeemed_from`. Ensure the redeemer customers exist.
+    const redeemers = event.redeemed_by ?? [];
+    for (const redeemerId of redeemers) {
+      await upsertCustomer(ctx, { ...event, app_user_id: redeemerId, aliases: undefined });
+    }
+    // `transfer`: a companion TRANSFER moves the purchase to the redeemer with
+    // the real product/expiry, so let that handler own the movement.
+    if (event.redemption_outcome === "transfer") return null;
+    // `alias`: the redeemer now resolves to the same RC customer as the original
+    // purchaser, so merge the original's entitlements/subscriptions onto the
+    // redeemer (the original purchase carries the correct expiry). The event has
+    // no expiration_at_ms, so a blanket grant here would mint lifetime access.
+    // `redeemer_owns` and unknown outcomes need no movement.
+    if (event.redemption_outcome === "alias") {
+      for (const fromUserId of event.redeemed_from ?? []) {
+        for (const toUserId of redeemers) {
+          if (fromUserId === toUserId) continue;
+          await aliasEntitlements(ctx, fromUserId, toUserId);
+          await transferSubscriptions(ctx, fromUserId, toUserId);
+          await aliasExperiments(ctx, fromUserId, toUserId);
+          await purgeAnonymousCustomerIfEmpty(ctx, fromUserId);
+        }
+      }
+    }
     return null;
   },
 });
@@ -1161,12 +1212,18 @@ export const processInvoiceIssuance = internalMutation({
           productId: event.product_id,
           store: event.store,
           environment: event.environment,
+          // RC `price` is already USD-normalized; `priceInPurchasedCurrency`
+          // carries the charged-currency amount.
           priceUsd: event.price,
           currency: event.currency,
           priceInPurchasedCurrency: event.price_in_purchased_currency,
           issuedAt: event.event_timestamp_ms,
         });
       }
+    } else {
+      console.warn(
+        `[revenuecat] processInvoiceIssuance skipped invoice for event ${event.id}: missing app_user_id or environment`,
+      );
     }
 
     return null;
@@ -1219,24 +1276,27 @@ export const processVirtualCurrencyTransaction = internalMutation({
       const currencyName = adjustment.currency.name;
       const amount = adjustment.amount;
 
-      // Dedup by (transactionId, currencyCode), one event can carry many
-      // adjustments under one transactionId.
-      if (!existingTx) {
-        await ctx.db.insert("virtualCurrencyTransactions", {
-          transactionId,
-          appUserId: event.app_user_id,
-          currencyCode,
-          amount,
-          source: event.source,
-          productId: event.product_id,
-          environment,
-          timestamp: event.event_timestamp_ms,
-        });
-      }
+      // Dedup by (transactionId, currencyCode): one event can carry many
+      // adjustments under one transactionId. Apply the delta only when the
+      // transaction is new, so a replay (same tx id under a different event id,
+      // or a direct re-invoke) can't double-count it. Clamp at 0 to mirror RC,
+      // whose ledger caps balances at 0 and never goes negative. The mirror is
+      // advisory; RC is the source of truth.
+      if (existingTx) continue;
+      await ctx.db.insert("virtualCurrencyTransactions", {
+        transactionId,
+        appUserId: event.app_user_id,
+        currencyCode,
+        amount,
+        source: event.source,
+        productId: event.product_id,
+        environment,
+        timestamp: event.event_timestamp_ms,
+      });
 
       if (existingBalance) {
         await ctx.db.patch(existingBalance._id, {
-          balance: existingBalance.balance + amount,
+          balance: Math.max(0, existingBalance.balance + amount),
           updatedAt: now,
         });
       } else {
@@ -1244,7 +1304,7 @@ export const processVirtualCurrencyTransaction = internalMutation({
           appUserId: event.app_user_id,
           currencyCode,
           currencyName,
-          balance: amount,
+          balance: Math.max(0, amount),
           updatedAt: now,
         });
       }

--- a/src/component/hooks.test.ts
+++ b/src/component/hooks.test.ts
@@ -30,14 +30,15 @@ async function scheduledJobsMatching(
   nameSuffix: string,
 ): Promise<ScheduledJob[]> {
   return await t.run(async (ctx) => {
-    const jobs = await ctx.db.system
-      .query("_scheduled_functions")
-      .collect();
+    const jobs = await ctx.db.system.query("_scheduled_functions").collect();
     return jobs
       .filter((j) => j.name.endsWith(nameSuffix))
       .map((j) => ({
         name: j.name,
-        args: (Array.isArray(j.args) ? j.args[0] : j.args) as Record<string, unknown>,
+        args: (Array.isArray(j.args) ? j.args[0] : j.args) as Record<
+          string,
+          unknown
+        >,
         state: j.state,
       }));
   });
@@ -86,7 +87,7 @@ describe("lifecycle hooks", () => {
         entitlement_ids: ["premium", "pro"],
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -106,12 +107,12 @@ describe("lifecycle hooks", () => {
         .map((j) => (j.args as { entitlementId: string }).entitlementId)
         .sort();
       expect(entIds).toEqual(["premium", "pro"]);
-      expect(
-        (jobs[0].args as { appUserId: string }).appUserId,
-      ).toBe("user_hook_initial");
-      expect(
-        (jobs[0].args as { productId?: string }).productId,
-      ).toBe("premium_monthly");
+      expect((jobs[0].args as { appUserId: string }).appUserId).toBe(
+        "user_hook_initial",
+      );
+      expect((jobs[0].args as { productId?: string }).productId).toBe(
+        "premium_monthly",
+      );
     });
 
     test("does not fire when the entitlement was already active", async () => {
@@ -120,7 +121,7 @@ describe("lifecycle hooks", () => {
       const userId = "user_hook_already_active";
 
       // First purchase activates.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_hook_a1",
           type: "INITIAL_PURCHASE",
@@ -128,12 +129,15 @@ describe("lifecycle hooks", () => {
           environment: "SANDBOX",
           store: "APP_STORE",
         },
-        payload: createPurchasePayload({ id: "evt_hook_a1", app_user_id: userId }),
+        payload: createPurchasePayload({
+          id: "evt_hook_a1",
+          app_user_id: userId,
+        }),
       });
 
       // Second event with the same entitlement but NEW transaction id shouldn't
       // double-fire the hook (state is already active).
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_hook_a2",
           type: "RENEWAL",
@@ -165,7 +169,7 @@ describe("lifecycle hooks", () => {
       });
 
       // First delivery activates + fires hook.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -179,7 +183,7 @@ describe("lifecycle hooks", () => {
 
       // RC retries, same event.id. The outer mutation short-circuits via
       // the webhookEvents dedup check. No snapshot or hook fires on retry.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -202,7 +206,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_hook_expire";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_hook_e1",
           type: "INITIAL_PURCHASE",
@@ -210,7 +214,10 @@ describe("lifecycle hooks", () => {
           environment: "SANDBOX",
           store: "APP_STORE",
         },
-        payload: createPurchasePayload({ id: "evt_hook_e1", app_user_id: userId }),
+        payload: createPurchasePayload({
+          id: "evt_hook_e1",
+          app_user_id: userId,
+        }),
       });
 
       const expirePayload = createPurchasePayload({
@@ -220,7 +227,7 @@ describe("lifecycle hooks", () => {
         expiration_at_ms: Date.now() - 1000,
         original_transaction_id: "txn_original_evt_hook_e1",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -234,9 +241,9 @@ describe("lifecycle hooks", () => {
 
       const jobs = await scheduledJobsMatching(t, "noop");
       expect(jobs).toHaveLength(1);
-      expect(
-        (jobs[0].args as { entitlementId: string }).entitlementId,
-      ).toBe("premium");
+      expect((jobs[0].args as { entitlementId: string }).entitlementId).toBe(
+        "premium",
+      );
       expect((jobs[0].args as { appUserId: string }).appUserId).toBe(userId);
     });
 
@@ -245,7 +252,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_hook_refund";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_hook_r1",
           type: "INITIAL_PURCHASE",
@@ -253,7 +260,10 @@ describe("lifecycle hooks", () => {
           environment: "SANDBOX",
           store: "APP_STORE",
         },
-        payload: createPurchasePayload({ id: "evt_hook_r1", app_user_id: userId }),
+        payload: createPurchasePayload({
+          id: "evt_hook_r1",
+          app_user_id: userId,
+        }),
       });
 
       const cancelPayload = {
@@ -265,7 +275,7 @@ describe("lifecycle hooks", () => {
         }),
         cancel_reason: "CUSTOMER_SUPPORT",
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: cancelPayload.id,
           type: cancelPayload.type,
@@ -289,7 +299,7 @@ describe("lifecycle hooks", () => {
       const source = "user_transfer_src";
       const dest = "user_transfer_dst";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_t_seed",
           type: "INITIAL_PURCHASE",
@@ -297,10 +307,13 @@ describe("lifecycle hooks", () => {
           environment: "SANDBOX",
           store: "APP_STORE",
         },
-        payload: createPurchasePayload({ id: "evt_t_seed", app_user_id: source }),
+        payload: createPurchasePayload({
+          id: "evt_t_seed",
+          app_user_id: source,
+        }),
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_transfer",
           type: "TRANSFER",
@@ -325,7 +338,9 @@ describe("lifecycle hooks", () => {
       });
 
       const jobs = await scheduledJobsMatching(t, "noop");
-      const users = jobs.map((j) => (j.args as { appUserId: string }).appUserId).sort();
+      const users = jobs
+        .map((j) => (j.args as { appUserId: string }).appUserId)
+        .sort();
       expect(users).toEqual([dest, source]);
     });
   });
@@ -363,9 +378,9 @@ describe("lifecycle hooks", () => {
 
       const jobs = await scheduledJobsMatching(t, "noop");
       expect(jobs).toHaveLength(1);
-      expect(
-        (jobs[0].args as { entitlementId: string }).entitlementId,
-      ).toBe("premium");
+      expect((jobs[0].args as { entitlementId: string }).entitlementId).toBe(
+        "premium",
+      );
     });
 
     test("fires deactivate hook when sync catches an expired entitlement", async () => {
@@ -428,9 +443,9 @@ describe("lifecycle hooks", () => {
 
       const jobs = await scheduledJobsMatching(t, "noop");
       expect(jobs).toHaveLength(1);
-      expect(
-        (jobs[0].args as { entitlementId: string }).entitlementId,
-      ).toBe("premium");
+      expect((jobs[0].args as { entitlementId: string }).entitlementId).toBe(
+        "premium",
+      );
     });
   });
 
@@ -439,7 +454,7 @@ describe("lifecycle hooks", () => {
       const t = initConvexTest();
       const handle = await handleFor(t, internal.lib.noop);
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_purge_seed",
           type: "INITIAL_PURCHASE",
@@ -460,9 +475,9 @@ describe("lifecycle hooks", () => {
 
       const jobs = await scheduledJobsMatching(t, "noop");
       expect(jobs).toHaveLength(1);
-      expect(
-        (jobs[0].args as { appUserId: string }).appUserId,
-      ).toBe("user_purge_hook");
+      expect((jobs[0].args as { appUserId: string }).appUserId).toBe(
+        "user_purge_hook",
+      );
     });
 
     test("does not fire when hook is omitted", async () => {
@@ -489,7 +504,7 @@ describe("lifecycle hooks", () => {
         purchased_at_ms: now,
         expiration_at_ms: now + 30 * 24 * 60 * 60 * 1000,
       };
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,
@@ -567,7 +582,7 @@ describe("lifecycle hooks", () => {
       const handle = await handleFor(t, internal.lib.noop);
       const userId = "user_deact_args";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_deact_args_1",
           type: "INITIAL_PURCHASE",
@@ -575,7 +590,10 @@ describe("lifecycle hooks", () => {
           environment: "SANDBOX",
           store: "APP_STORE",
         },
-        payload: createPurchasePayload({ id: "evt_deact_args_1", app_user_id: userId }),
+        payload: createPurchasePayload({
+          id: "evt_deact_args_1",
+          app_user_id: userId,
+        }),
       });
 
       const expirePayload = createPurchasePayload({
@@ -585,7 +603,7 @@ describe("lifecycle hooks", () => {
         expiration_at_ms: Date.now() - 1000,
         original_transaction_id: "txn_original_evt_deact_args_1",
       });
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: expirePayload.id,
           type: expirePayload.type,
@@ -618,7 +636,7 @@ describe("lifecycle hooks", () => {
       // No handler matches a UNKNOWN event type, so the dispatch table
       // short-circuits to status="ignored" and never reads entitlements or
       // fires hooks.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_unknown_rollback",
           type: "FUTURE_UNKNOWN_EVENT",
@@ -643,7 +661,7 @@ describe("lifecycle hooks", () => {
       const t = initConvexTest();
       const handle = await handleFor(t, internal.lib.noop);
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_test",
           type: "TEST",
@@ -674,7 +692,7 @@ describe("lifecycle hooks", () => {
       const real = "user_real";
 
       // Seed an anonymous user with an active entitlement.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_alias_seed",
           type: "INITIAL_PURCHASE",
@@ -692,7 +710,7 @@ describe("lifecycle hooks", () => {
       // aliases array carries both IDs. AffectedUserIds must pick up both so
       // the migration's deactivation from anon and activation on real are
       // detected.
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_alias_migrate",
           type: "SUBSCRIBER_ALIAS",
@@ -733,7 +751,7 @@ describe("lifecycle hooks", () => {
         app_user_id: "user_no_hooks",
       });
 
-      const result = await t.mutation(internal.webhooks.process, {
+      const result = await t.mutation(api.webhooks.process, {
         event: {
           id: payload.id,
           type: payload.type,

--- a/src/component/invoices.test.ts
+++ b/src/component/invoices.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { initConvexTest } from "./setup.test.js";
-import { api, internal } from "./_generated/api.js";
+import { api } from "./_generated/api.js";
 
 describe("invoices", () => {
   describe("get", () => {
@@ -16,7 +16,7 @@ describe("invoices", () => {
       const t = initConvexTest();
 
       // INVOICE_ISSUANCE uses event.id as the invoice identifier (no separate invoice_id field)
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_invoice_1",
           type: "INVOICE_ISSUANCE",
@@ -65,7 +65,7 @@ describe("invoices", () => {
       const userId = "user_multi_invoice";
 
       for (let i = 1; i <= 3; i++) {
-        await t.mutation(internal.webhooks.process, {
+        await t.mutation(api.webhooks.process, {
           event: {
             id: `evt_inv_${i}`,
             type: "INVOICE_ISSUANCE",

--- a/src/component/parity-fixes.test.ts
+++ b/src/component/parity-fixes.test.ts
@@ -42,8 +42,7 @@ function basePayload(
     expiration_at_ms:
       overrides.expiration_at_ms ?? now + 30 * 24 * 60 * 60 * 1000,
     transaction_id: overrides.transaction_id ?? `txn_${now}`,
-    original_transaction_id:
-      overrides.original_transaction_id ?? `otxn_${now}`,
+    original_transaction_id: overrides.original_transaction_id ?? `otxn_${now}`,
     store: overrides.store ?? ("APP_STORE" as const),
     environment: "SANDBOX" as const,
     is_family_share: false,
@@ -61,7 +60,7 @@ async function dispatch(
   t: ReturnType<typeof initConvexTest>,
   payload: ReturnType<typeof basePayload>,
 ) {
-  await t.mutation(internal.webhooks.process, {
+  await t.mutation(api.webhooks.process, {
     event: {
       id: payload.id,
       type: payload.type,
@@ -162,7 +161,8 @@ describe("parity fixes", () => {
           type: "BILLING_ISSUE",
           app_user_id: "user_p2",
           expiration_at_ms: initialExpiry,
-          grace_period_expiration_at_ms: initialExpiry + 7 * 24 * 60 * 60 * 1000,
+          grace_period_expiration_at_ms:
+            initialExpiry + 7 * 24 * 60 * 60 * 1000,
           original_transaction_id: sharedTxn,
           transaction_id: sharedTxn,
         }),
@@ -271,7 +271,8 @@ describe("parity fixes", () => {
           type: "BILLING_ISSUE",
           app_user_id: "user_p3",
           expiration_at_ms: initialExpiry,
-          grace_period_expiration_at_ms: initialExpiry + 7 * 24 * 60 * 60 * 1000,
+          grace_period_expiration_at_ms:
+            initialExpiry + 7 * 24 * 60 * 60 * 1000,
           original_transaction_id: sharedTxn,
           transaction_id: sharedTxn,
         }),
@@ -794,8 +795,20 @@ describe("parity fixes", () => {
       const t = initConvexTest();
       const destExpiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
-      await seedEntitlement(t, "user_life_src", "otxn_life_src", undefined, "evt_life_src");
-      await seedEntitlement(t, "user_life_dst", "otxn_life_dst", destExpiry, "evt_life_dst");
+      await seedEntitlement(
+        t,
+        "user_life_src",
+        "otxn_life_src",
+        undefined,
+        "evt_life_src",
+      );
+      await seedEntitlement(
+        t,
+        "user_life_dst",
+        "otxn_life_dst",
+        destExpiry,
+        "evt_life_dst",
+      );
 
       await t.mutation(internal.handlers.processTransfer, {
         event: {
@@ -823,8 +836,20 @@ describe("parity fixes", () => {
       const t = initConvexTest();
       const srcExpiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
-      await seedEntitlement(t, "user_flife_dst", "otxn_flife_dst", undefined, "evt_flife_dst");
-      await seedEntitlement(t, "user_flife_src", "otxn_flife_src", srcExpiry, "evt_flife_src");
+      await seedEntitlement(
+        t,
+        "user_flife_dst",
+        "otxn_flife_dst",
+        undefined,
+        "evt_flife_dst",
+      );
+      await seedEntitlement(
+        t,
+        "user_flife_src",
+        "otxn_flife_src",
+        srcExpiry,
+        "evt_flife_src",
+      );
 
       await t.mutation(internal.handlers.processTransfer, {
         event: {
@@ -852,8 +877,20 @@ describe("parity fixes", () => {
       const t = initConvexTest();
       const existingExpiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
-      await seedEntitlement(t, "user_alias_existing", "otxn_ae", existingExpiry, "evt_alias_ex");
-      await seedEntitlement(t, "$RCAnonymousID:alias_src_life", "otxn_als", undefined, "evt_als");
+      await seedEntitlement(
+        t,
+        "user_alias_existing",
+        "otxn_ae",
+        existingExpiry,
+        "evt_alias_ex",
+      );
+      await seedEntitlement(
+        t,
+        "$RCAnonymousID:alias_src_life",
+        "otxn_als",
+        undefined,
+        "evt_als",
+      );
 
       await t.mutation(internal.handlers.processSubscriberAlias, {
         event: {
@@ -879,8 +916,20 @@ describe("parity fixes", () => {
       const t = initConvexTest();
       const srcExpiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
-      await seedEntitlement(t, "user_alias_life_ex", "otxn_ale", undefined, "evt_alias_le");
-      await seedEntitlement(t, "$RCAnonymousID:alias_src_fin", "otxn_alsf", srcExpiry, "evt_alsf");
+      await seedEntitlement(
+        t,
+        "user_alias_life_ex",
+        "otxn_ale",
+        undefined,
+        "evt_alias_le",
+      );
+      await seedEntitlement(
+        t,
+        "$RCAnonymousID:alias_src_fin",
+        "otxn_alsf",
+        srcExpiry,
+        "evt_alsf",
+      );
 
       await t.mutation(internal.handlers.processSubscriberAlias, {
         event: {
@@ -919,7 +968,8 @@ describe("parity fixes", () => {
           subscriptions: { premium_monthly: sub },
           entitlements: {
             premium: {
-              expires_date: (sub.expires_date as string | null | undefined) ?? null,
+              expires_date:
+                (sub.expires_date as string | null | undefined) ?? null,
               product_identifier: "premium_monthly",
               purchase_date: "2026-01-01T00:00:00Z",
             },

--- a/src/component/skills-audit.test.ts
+++ b/src/component/skills-audit.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api.js";
+import { initConvexTest } from "./setup.test.js";
+
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+describe("PURCHASE_REDEEMED", () => {
+  test("alias outcome merges the original purchaser's access onto the redeemer", async () => {
+    const t = initConvexTest();
+    const anon = "$RCAnonymousID:redeem_anon";
+    const redeemer = "user_redeemer";
+    const future = Date.now() + MONTH_MS;
+
+    // Seed the original Web Billing purchase under the anonymous purchaser.
+    await t.mutation(api.webhooks.process, {
+      event: {
+        id: "evt_redeem_seed",
+        type: "INITIAL_PURCHASE",
+        app_user_id: anon,
+        environment: "PRODUCTION" as const,
+        store: "RC_BILLING" as const,
+      },
+      payload: {
+        id: "evt_redeem_seed",
+        type: "INITIAL_PURCHASE",
+        app_user_id: anon,
+        event_timestamp_ms: Date.now(),
+        product_id: "premium_monthly",
+        entitlement_ids: ["premium"],
+        period_type: "NORMAL",
+        store: "RC_BILLING",
+        environment: "PRODUCTION",
+        original_transaction_id: "txn_redeem",
+        transaction_id: "txn_redeem",
+        expiration_at_ms: future,
+      },
+    });
+
+    // Redeem: the redeemer is aliased to the anonymous purchaser. No top-level
+    // app_user_id; redeemer in redeemed_by, original in redeemed_from.
+    await t.mutation(api.webhooks.process, {
+      event: {
+        id: "evt_redeem_alias",
+        type: "PURCHASE_REDEEMED",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "evt_redeem_alias",
+        type: "PURCHASE_REDEEMED",
+        event_timestamp_ms: Date.now(),
+        environment: "PRODUCTION",
+        redeemed_from: [anon],
+        redeemed_by: [redeemer],
+        redemption_outcome: "alias",
+        entitlement_ids: ["premium"],
+      },
+    });
+
+    // Access moved to the redeemer carrying the original expiry, and the
+    // anonymous source no longer holds it. (No lifetime grant was minted.)
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: redeemer,
+        entitlementId: "premium",
+      }),
+    ).toBe(true);
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: anon,
+        entitlementId: "premium",
+      }),
+    ).toBe(false);
+  });
+
+  test("transfer outcome defers to the companion TRANSFER (no grant here)", async () => {
+    const t = initConvexTest();
+    const redeemer = "user_xfer_dest";
+
+    await t.mutation(api.webhooks.process, {
+      event: {
+        id: "evt_redeem_xfer",
+        type: "PURCHASE_REDEEMED",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "evt_redeem_xfer",
+        type: "PURCHASE_REDEEMED",
+        event_timestamp_ms: Date.now(),
+        environment: "PRODUCTION",
+        redeemed_from: ["$RCAnonymousID:xfer_src"],
+        redeemed_by: [redeemer],
+        redemption_outcome: "transfer",
+        entitlement_ids: ["premium"],
+      },
+    });
+
+    // PURCHASE_REDEEMED alone grants nothing on a transfer outcome; the
+    // companion TRANSFER (not sent here) carries the real movement.
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: redeemer,
+        entitlementId: "premium",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("virtual currency", () => {
+  test("balance is not double-applied when a transaction id replays under a new event id", async () => {
+    const t = initConvexTest();
+    const userId = "user_vc_replay";
+    const adjustment = {
+      type: "VIRTUAL_CURRENCY_TRANSACTION",
+      app_user_id: userId,
+      environment: "PRODUCTION",
+      virtual_currency_transaction_id: "vct_replay",
+      event_timestamp_ms: Date.now(),
+      adjustments: [
+        { amount: 100, currency: { code: "COINS", name: "Coins" } },
+      ],
+    };
+
+    // Same tx id, two distinct event ids (RC at-least-once delivery edge).
+    for (const eventId of ["evt_vc_replay_a", "evt_vc_replay_b"]) {
+      await t.mutation(api.webhooks.process, {
+        event: {
+          id: eventId,
+          type: "VIRTUAL_CURRENCY_TRANSACTION",
+          app_user_id: userId,
+          environment: "PRODUCTION" as const,
+        },
+        payload: { ...adjustment, id: eventId },
+      });
+    }
+
+    const balance = await t.query(api.virtualCurrency.getBalance, {
+      appUserId: userId,
+      currencyCode: "COINS",
+    });
+    expect(balance?.balance).toBe(100);
+
+    const txns = await t.query(api.virtualCurrency.listTransactions, {
+      appUserId: userId,
+    });
+    expect(txns.length).toBe(1);
+  });
+
+  test("balance is clamped at 0 to mirror RC (no negative balances)", async () => {
+    const t = initConvexTest();
+    const userId = "user_vc_clamp";
+    const adjust = (id: string, amount: number) => ({
+      event: {
+        id,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        app_user_id: userId,
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id,
+        type: "VIRTUAL_CURRENCY_TRANSACTION",
+        app_user_id: userId,
+        environment: "PRODUCTION",
+        virtual_currency_transaction_id: `vct_${id}`,
+        event_timestamp_ms: Date.now(),
+        adjustments: [{ amount, currency: { code: "COINS", name: "Coins" } }],
+      },
+    });
+
+    await t.mutation(api.webhooks.process, adjust("clamp_grant", 50));
+    await t.mutation(api.webhooks.process, adjust("clamp_spend", -80));
+
+    const balance = await t.query(api.virtualCurrency.getBalance, {
+      appUserId: userId,
+      currencyCode: "COINS",
+    });
+    expect(balance?.balance).toBe(0); // not -30
+  });
+});
+
+describe("invoice price fields", () => {
+  test("priceUsd holds RC's USD-normalized price regardless of purchase currency", async () => {
+    const t = initConvexTest();
+
+    await t.mutation(api.webhooks.process, {
+      event: {
+        id: "inv_eur",
+        type: "INVOICE_ISSUANCE",
+        app_user_id: "user_inv_eur",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "inv_eur",
+        type: "INVOICE_ISSUANCE",
+        app_user_id: "user_inv_eur",
+        environment: "PRODUCTION",
+        event_timestamp_ms: Date.now(),
+        price: 10.5, // RC `price` is the USD price of the transaction
+        currency: "EUR",
+        price_in_purchased_currency: 9.99,
+      },
+    });
+
+    const inv = await t.run(async (ctx) =>
+      ctx.db
+        .query("invoices")
+        .withIndex("by_invoice_id", (q) => q.eq("invoiceId", "inv_eur"))
+        .first(),
+    );
+    expect(inv?.priceUsd).toBe(10.5);
+    expect(inv?.priceInPurchasedCurrency).toBe(9.99);
+    expect(inv?.currency).toBe("EUR");
+  });
+});
+
+describe("GDPR purge of transfer audit rows", () => {
+  test("removes the TRANSFER webhookEvent (stored with a null appUserId)", async () => {
+    const t = initConvexTest();
+
+    await t.mutation(api.webhooks.process, {
+      event: {
+        id: "evt_transfer_purge",
+        type: "TRANSFER",
+        environment: "PRODUCTION" as const,
+      },
+      payload: {
+        id: "evt_transfer_purge",
+        type: "TRANSFER",
+        environment: "PRODUCTION",
+        event_timestamp_ms: Date.now(),
+        transferred_from: ["user_transfer_src"],
+        transferred_to: ["user_transfer_dst"],
+        entitlement_ids: ["premium"],
+      },
+    });
+
+    const result = await t.mutation(api.customers.purge, {
+      appUserId: "user_transfer_dst",
+    });
+    expect(result.transfers).toBe(1);
+    expect(result.webhookEvents).toBe(1);
+
+    const auditRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("webhookEvents")
+        .withIndex("by_event_id", (q) => q.eq("eventId", "evt_transfer_purge"))
+        .first(),
+    );
+    expect(auditRow).toBeNull();
+  });
+});
+
+describe("grace period sub/entitlement consistency", () => {
+  test("subscription and entitlement agree during a billing-issue grace period", async () => {
+    const t = initConvexTest();
+    const userId = "user_grace_consistency";
+    const now = Date.now();
+    const past = now - 60_000; // original period just ended
+    const graceEnd = now + 7 * 24 * 60 * 60 * 1000;
+    const base = {
+      app_id: "app_123",
+      app_user_id: userId,
+      event_timestamp_ms: now,
+      product_id: "premium_monthly",
+      entitlement_ids: ["premium"],
+      period_type: "NORMAL",
+      store: "APP_STORE",
+      environment: "SANDBOX",
+      original_transaction_id: "txn_grace",
+      transaction_id: "txn_grace",
+      expiration_at_ms: past,
+    };
+    const event = (id: string, type: string) => ({
+      id,
+      type,
+      app_user_id: userId,
+      environment: "SANDBOX" as const,
+      store: "APP_STORE" as const,
+    });
+
+    await t.mutation(api.webhooks.process, {
+      event: event("evt_grace_init", "INITIAL_PURCHASE"),
+      payload: { ...base, id: "evt_grace_init", type: "INITIAL_PURCHASE" },
+    });
+    await t.mutation(api.webhooks.process, {
+      event: event("evt_grace_billing", "BILLING_ISSUE"),
+      payload: {
+        ...base,
+        id: "evt_grace_billing",
+        type: "BILLING_ISSUE",
+        grace_period_expiration_at_ms: graceEnd,
+      },
+    });
+
+    // The entitlement gate (expiry pushed to grace-end at write time) and the
+    // subscription grace-fold (Math.max(expiry, graceEnd) live) must agree:
+    // both active through grace even though the original period has ended.
+    expect(
+      await t.query(api.entitlements.check, {
+        appUserId: userId,
+        entitlementId: "premium",
+      }),
+    ).toBe(true);
+    expect(
+      await t.query(api.subscriptions.getActive, { appUserId: userId }),
+    ).toHaveLength(1);
+    const grace = await t.query(api.subscriptions.isInGracePeriod, {
+      originalTransactionId: "txn_grace",
+    });
+    expect(grace.inGracePeriod).toBe(true);
+  });
+});

--- a/src/component/subscriptions.ts
+++ b/src/component/subscriptions.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { paginator } from "convex-helpers/server/pagination";
-import { internalMutation, query } from "./_generated/server.js";
+import { mutation, query } from "./_generated/server.js";
 import schema from "./schema.js";
 
 const subscriptionDoc = schema.tables.subscriptions.validator.extend({
@@ -27,6 +27,9 @@ export const getActive = query({
   },
   returns: v.array(subscriptionDoc),
   handler: async (ctx, args) => {
+    // `Date.now()` is deliberate here (see entitlements.ts header): it keeps the
+    // active/grace filter reactive between lifecycle webhooks. Per-user tables
+    // are tiny, so the query-cache cost is negligible.
     const now = Date.now();
     const subscriptions = await ctx.db
       .query("subscriptions")
@@ -40,7 +43,10 @@ export const getActive = query({
       // consumables call `getConsumables`.
       if (s.kind === "consumable") return false;
       if (!s.expirationAtMs) return true;
-      const effectiveExpiration = Math.max(s.expirationAtMs, s.gracePeriodExpirationAtMs ?? 0);
+      const effectiveExpiration = Math.max(
+        s.expirationAtMs,
+        s.gracePeriodExpirationAtMs ?? 0,
+      );
       return effectiveExpiration > now;
     });
   },
@@ -74,7 +80,7 @@ export const getConsumables = query({
  * NON_RENEWING_PURCHASE event predates retention can't be backfilled this
  * way and stay `kind: undefined` (so `getActiveSubscriptions` will keep
  * returning them). Operators with older data should patch directly. */
-export const backfillKind = internalMutation({
+export const backfillKind = mutation({
   args: {
     cursor: v.optional(v.string()),
     pageSize: v.optional(v.number()),
@@ -93,9 +99,9 @@ export const backfillKind = internalMutation({
     const now = Date.now();
     let written = 0;
     for (const event of page.page) {
-      const payload = event.payload as
-        | { original_transaction_id?: string }
-        | null;
+      const payload = event.payload as {
+        original_transaction_id?: string;
+      } | null;
       const originalTransactionId = payload?.original_transaction_id;
       if (!originalTransactionId) continue;
       const sub = await ctx.db
@@ -164,8 +170,8 @@ export const isInGracePeriod = query({
     // original expiry).
     const inGracePeriod = Boolean(
       billingIssueDetectedAt &&
-        gracePeriodExpirationAtMs &&
-        gracePeriodExpirationAtMs > now,
+      gracePeriodExpirationAtMs &&
+      gracePeriodExpirationAtMs > now,
     );
 
     return {
@@ -193,8 +199,8 @@ export const getInGracePeriod = query({
       // rationale on dropping the `normalExpired` clause.
       return Boolean(
         s.billingIssueDetectedAt &&
-          s.gracePeriodExpirationAtMs &&
-          s.gracePeriodExpirationAtMs > now,
+        s.gracePeriodExpirationAtMs &&
+        s.gracePeriodExpirationAtMs > now,
       );
     });
   },

--- a/src/component/transfers.test.ts
+++ b/src/component/transfers.test.ts
@@ -15,7 +15,7 @@ describe("transfers", () => {
     test("returns transfer after TRANSFER event", async () => {
       const t = initConvexTest();
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_transfer_1",
           type: "TRANSFER",
@@ -54,7 +54,7 @@ describe("transfers", () => {
       const t = initConvexTest();
       const now = Date.now();
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_transfer_old",
           type: "TRANSFER",
@@ -70,7 +70,7 @@ describe("transfers", () => {
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_transfer_new",
           type: "TRANSFER",
@@ -128,7 +128,7 @@ describe("transfers", () => {
       expect(sourceSubs).toHaveLength(1);
 
       // Process TRANSFER event
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_transfer_sub",
           type: "TRANSFER",

--- a/src/component/transfers.ts
+++ b/src/component/transfers.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { paginator } from "convex-helpers/server/pagination";
-import { internalMutation, query } from "./_generated/server.js";
+import { mutation, query } from "./_generated/server.js";
 import schema from "./schema.js";
 
 const transferDoc = schema.tables.transfers.validator.extend({
@@ -26,7 +26,10 @@ export const list = query({
   args: { limit: v.optional(v.number()) },
   returns: v.array(transferDoc),
   handler: async (ctx, args) => {
-    const limit = Math.min(args.limit ?? TRANSFER_LIMIT_DEFAULT, TRANSFER_LIMIT_MAX);
+    const limit = Math.min(
+      args.limit ?? TRANSFER_LIMIT_DEFAULT,
+      TRANSFER_LIMIT_MAX,
+    );
     return await ctx.db
       .query("transfers")
       .withIndex("by_timestamp")
@@ -37,7 +40,7 @@ export const list = query({
 
 /** Backfill `transferParticipants` for pre-0.3.0 `transfers` rows. Run once
  * after upgrading. Idempotent. Loop until `nextCursor` is null. */
-export const backfillTransferParticipants = internalMutation({
+export const backfillTransferParticipants = mutation({
   args: {
     cursor: v.optional(v.string()),
     pageSize: v.optional(v.number()),

--- a/src/component/virtualCurrency.test.ts
+++ b/src/component/virtualCurrency.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { initConvexTest } from "./setup.test.js";
-import { api, internal } from "./_generated/api.js";
+import { api } from "./_generated/api.js";
 
 describe("virtualCurrency", () => {
   describe("getBalance", () => {
@@ -16,7 +16,7 @@ describe("virtualCurrency", () => {
     test("returns balance after VIRTUAL_CURRENCY_TRANSACTION event", async () => {
       const t = initConvexTest();
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_vc_1",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -59,7 +59,7 @@ describe("virtualCurrency", () => {
       const userId = "user_vc_accumulate";
 
       // First transaction: +100
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_vc_add",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -83,7 +83,7 @@ describe("virtualCurrency", () => {
       });
 
       // Second transaction: -30 (refund)
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_vc_sub",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -120,7 +120,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_multi_currency";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_vc_multi",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -157,7 +157,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_tx_list";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_tx_1",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -172,11 +172,13 @@ describe("virtualCurrency", () => {
           environment: "PRODUCTION",
           virtual_currency_transaction_id: "vct_1",
           source: "in_app_purchase",
-          adjustments: [{ amount: 100, currency: { code: "COINS", name: "Coins" } }],
+          adjustments: [
+            { amount: 100, currency: { code: "COINS", name: "Coins" } },
+          ],
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_tx_2",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -191,7 +193,9 @@ describe("virtualCurrency", () => {
           environment: "PRODUCTION",
           virtual_currency_transaction_id: "vct_2",
           source: "admin_api",
-          adjustments: [{ amount: 50, currency: { code: "COINS", name: "Coins" } }],
+          adjustments: [
+            { amount: 50, currency: { code: "COINS", name: "Coins" } },
+          ],
         },
       });
 
@@ -206,7 +210,7 @@ describe("virtualCurrency", () => {
       const t = initConvexTest();
       const userId = "user_tx_filter";
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_tx_coins",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -220,11 +224,13 @@ describe("virtualCurrency", () => {
           app_user_id: userId,
           environment: "PRODUCTION",
           virtual_currency_transaction_id: "vct_coins",
-          adjustments: [{ amount: 100, currency: { code: "COINS", name: "Coins" } }],
+          adjustments: [
+            { amount: 100, currency: { code: "COINS", name: "Coins" } },
+          ],
         },
       });
 
-      await t.mutation(internal.webhooks.process, {
+      await t.mutation(api.webhooks.process, {
         event: {
           id: "evt_tx_gems",
           type: "VIRTUAL_CURRENCY_TRANSACTION",
@@ -238,7 +244,9 @@ describe("virtualCurrency", () => {
           app_user_id: userId,
           environment: "PRODUCTION",
           virtual_currency_transaction_id: "vct_gems",
-          adjustments: [{ amount: 50, currency: { code: "GEMS", name: "Gems" } }],
+          adjustments: [
+            { amount: 50, currency: { code: "GEMS", name: "Gems" } },
+          ],
         },
       });
 

--- a/src/component/webhooks.test.ts
+++ b/src/component/webhooks.test.ts
@@ -25,7 +25,8 @@ function createEventPayload(
     entitlement_ids: overrides.entitlement_ids ?? ["premium"],
     period_type: "NORMAL" as const,
     purchased_at_ms: Date.now(),
-    expiration_at_ms: overrides.expiration_at_ms ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
+    expiration_at_ms:
+      overrides.expiration_at_ms ?? Date.now() + 30 * 24 * 60 * 60 * 1000,
     transaction_id: "txn_123",
     original_transaction_id: "txn_original_123",
     store: "APP_STORE" as const,
@@ -41,7 +42,7 @@ describe("webhook validation", () => {
     const payload = createEventPayload({ id: "   " });
 
     await expect(
-      t.mutation(internal.webhooks.process, {
+      t.mutation(api.webhooks.process, {
         event: {
           id: "   ",
           type: payload.type,
@@ -58,7 +59,7 @@ describe("webhook validation", () => {
     const payload = createEventPayload({ id: "evt_valid_id" });
 
     await expect(
-      t.mutation(internal.webhooks.process, {
+      t.mutation(api.webhooks.process, {
         event: {
           id: "evt_valid_id",
           type: "   ",
@@ -96,12 +97,15 @@ describe("future-proofing", () => {
     // then drops. This test guards against regression.
     const t = initConvexTest();
     const payload = {
-      ...createEventPayload({ id: "evt_unknown_fields", app_user_id: "user_future" }),
+      ...createEventPayload({
+        id: "evt_unknown_fields",
+        app_user_id: "user_future",
+      }),
       future_field_xyz: "value",
       another_future_field: 42,
       nested_future_object: { a: 1, b: [true, null] },
     };
-    await t.mutation(internal.webhooks.process, {
+    await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -126,7 +130,7 @@ describe("webhooks", () => {
 
     const payload = createEventPayload({ id: "evt_123" });
 
-    const result = await t.mutation(internal.webhooks.process, {
+    const result = await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -147,7 +151,7 @@ describe("webhooks", () => {
 
     const payload = createEventPayload({ id: "evt_456", type: "RENEWAL" });
 
-    const first = await t.mutation(internal.webhooks.process, {
+    const first = await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -158,7 +162,7 @@ describe("webhooks", () => {
 
     expect(first.processed).toBe(true);
 
-    const second = await t.mutation(internal.webhooks.process, {
+    const second = await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -181,7 +185,7 @@ describe("webhooks", () => {
       environment: "SANDBOX" as const,
     };
 
-    const result = await t.mutation(internal.webhooks.process, {
+    const result = await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,
@@ -194,7 +198,7 @@ describe("webhooks", () => {
     expect(result.processed).toBe(false);
     expect(result.eventId).toBe("evt_unknown_1");
 
-    const secondResult = await t.mutation(internal.webhooks.process, {
+    const secondResult = await t.mutation(api.webhooks.process, {
       event: {
         id: payload.id,
         type: payload.type,

--- a/src/component/webhooks.ts
+++ b/src/component/webhooks.ts
@@ -1,5 +1,5 @@
 import { v, ConvexError } from "convex/values";
-import { internalMutation } from "./_generated/server.js";
+import { internalMutation, mutation } from "./_generated/server.js";
 import { internal } from "./_generated/api.js";
 import { environmentValidator, storeValidator } from "./schema.js";
 import {
@@ -35,13 +35,18 @@ const EVENT_HANDLERS = {
   PRODUCT_CHANGE: internal.handlers.processProductChange,
   NON_RENEWING_PURCHASE: internal.handlers.processNonRenewingPurchase,
   TRANSFER: internal.handlers.processTransfer,
-  TEMPORARY_ENTITLEMENT_GRANT: internal.handlers.processTemporaryEntitlementGrant,
+  PURCHASE_REDEEMED: internal.handlers.processPurchaseRedeemed,
+  TEMPORARY_ENTITLEMENT_GRANT:
+    internal.handlers.processTemporaryEntitlementGrant,
   REFUND: internal.handlers.processRefund,
   REFUND_REVERSED: internal.handlers.processRefundReversed,
   TEST: internal.handlers.processTest,
   INVOICE_ISSUANCE: internal.handlers.processInvoiceIssuance,
-  VIRTUAL_CURRENCY_TRANSACTION: internal.handlers.processVirtualCurrencyTransaction,
+  VIRTUAL_CURRENCY_TRANSACTION:
+    internal.handlers.processVirtualCurrencyTransaction,
   EXPERIMENT_ENROLLMENT: internal.handlers.processExperimentEnrollment,
+  // Legacy/non-primary event: modern RC reflects aliasing through the customer
+  // fields on every event. Kept for back-compat; harmless if it never fires.
   SUBSCRIBER_ALIAS: internal.handlers.processSubscriberAlias,
 } as const;
 
@@ -57,14 +62,25 @@ export const checkRateLimit = internalMutation({
   handler: async (ctx, args) => {
     const now = Date.now();
 
+    // Bound the read to the limit: we only need to know whether the window is
+    // at capacity and the oldest row (for `resetAt`), not the exact overage.
+    // This caps read amplification when one key is flooded. The key is derived
+    // from caller-supplied `app_id`/`app_user_id` (see `process`), so the
+    // bucket is best-effort tenant fairness, not a security boundary. Concurrent
+    // webhooks for the same key overlap this read range and the insert below,
+    // so they can OCC-conflict and retry; correctness holds, and at RC webhook
+    // volumes the contention is negligible.
     const currentRequests = await ctx.db
       .query("rateLimits")
       .withIndex("by_key_and_time", (q) =>
         q.eq("key", args.key).gte("timestamp", now - RATE_LIMIT_WINDOW_MS),
       )
-      .collect();
+      .take(RATE_LIMIT_MAX_REQUESTS);
 
-    const remaining = Math.max(0, RATE_LIMIT_MAX_REQUESTS - currentRequests.length);
+    const remaining = Math.max(
+      0,
+      RATE_LIMIT_MAX_REQUESTS - currentRequests.length,
+    );
     const allowed = remaining > 0;
 
     if (allowed) {
@@ -80,7 +96,12 @@ export const checkRateLimit = internalMutation({
   },
 });
 
-export const process = internalMutation({
+// Public so the parent app's HTTP handler can call it via
+// `components.revenuecat.webhooks.process`. A component's internalMutation is
+// NOT exposed in the generated ComponentApi, so the parent couldn't reach it.
+// It's parent-callable only (never internet-addressable); the HTTP layer auth
+// is the security boundary.
+export const process = mutation({
   args: {
     event: v.object({
       id: v.string(),
@@ -103,7 +124,10 @@ export const process = internalMutation({
     const now = Date.now();
 
     if (!event.id?.trim()) {
-      throw new ConvexError({ code: "INVALID_ARGUMENT", message: "Event ID is required" });
+      throw new ConvexError({
+        code: "INVALID_ARGUMENT",
+        message: "Event ID is required",
+      });
     }
     if (event.id.length > MAX_EVENT_ID_LENGTH) {
       throw new ConvexError({
@@ -112,7 +136,10 @@ export const process = internalMutation({
       });
     }
     if (!event.type?.trim()) {
-      throw new ConvexError({ code: "INVALID_ARGUMENT", message: "Event type is required" });
+      throw new ConvexError({
+        code: "INVALID_ARGUMENT",
+        message: "Event type is required",
+      });
     }
 
     // Dedup before rate-limit so replays don't burn the bucket.
@@ -201,7 +228,7 @@ export const process = internalMutation({
  * transaction so the row survives the inner mutation's rollback. Called
  * from the HTTP boundary. Transient failures still roll back without an
  * audit row so RC retries cleanly. */
-export const recordFailure = internalMutation({
+export const recordFailure = mutation({
   args: {
     event: v.object({
       id: v.string(),


### PR DESCRIPTION
Closes #19.

## Fixes

- make parent-callable functions public: `process`, `recordFailure`, `subscriptions.backfillKind`, `transfers.backfillTransferParticipants`. `checkRateLimit`, `handlers.*`, and `cleanup.*` stay internal; the component self-schedules cleanup via its own `crons.ts`.
- regenerate `_generated` from `convex codegen` against a live deployment, retiring the hand-authored shim and the drift risk for good.
- handle `PURCHASE_REDEEMED`: merge `redeemed_from` into `redeemed_by` on an `alias` outcome, defer `transfer` outcomes to the companion `TRANSFER`.
- dedup the virtual-currency balance write and clamp at 0 to mirror RC's ledger.
- store `priceUsd` unconditionally (RC `price` is already USD-normalized).
- purge `TRANSFER` audit rows (null `appUserId`) on `deleteCustomer`.
- bound the rate-limit read so a flooded key can't amplify reads.
- the contract test now guards against re-internalizing a parent-called function.

## Example

`example/` is a runnable Vite + React app on a live deployment (`npm run example`):
- real RevenueCat Web SDK purchases of every offering (Monthly, Yearly, Lifetime) through the Test Store, firing real webhooks over the HTTP path.
- a simulator for every webhook the component handles (renewal, product change, billing issue, expiration, refund, transfer, redeem, virtual currency, invoice, experiment, and the rest) covering the events RC won't emit on demand.
- live reactive panels for entitlement, subscription, grace, customer, virtual-currency, invoice, and webhook-event state, plus a `reset` to start from a clean slate.

## Validation

314 tests, lint, typecheck (including the example), and the frontend build all green.
