### PR TITLE
fix(handlers): keep entitlements granted by another active subscription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,13 @@
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
-When working on Convex code, **always read `example/convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
+When working on Convex code, **always read
+`example/convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
 
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
+
 <!-- convex-ai-end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,9 @@ rows, and dead surface trimmed.
 
 ### Added
 
-- Regression tests for both fixes and the batched purge, plus hardening tests
-  (cross-user IDOR, PII redaction, `willRenew` drift, safety caps).
+- Regression tests for each fix and the batched purge, plus hardening tests
+  (cross-user IDOR, PII redaction, `willRenew` drift, safety caps, multi-product
+  entitlement keep).
 - `publish.yml` runs the full `validate`, and PR CI runs on Node 20 and 24.
 
 ## [0.3.1] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
-## [Unreleased]
-
 ## [0.3.2] - 2026-05-27
 
-A correctness and hardening release from a full line-by-line audit. Two real
-bugs fixed (a transfer could re-grant refunded access, a redemption could leave
-PII after a GDPR purge), the purge no longer caps at 500 rows, and dead surface
-trimmed.
+A correctness and hardening release from a full line-by-line audit. Three real
+bugs fixed (an expiring or refunded product could revoke an entitlement another
+active product still grants, a transfer could re-grant refunded access, a
+redemption could leave PII after a GDPR purge), the purge no longer caps at 500
+rows, and dead surface trimmed.
 
 ### Fixed
 
+- `EXPIRATION` and refund `CANCELLATION` no longer revoke an entitlement that a
+  different active subscription still grants. `revokeEntitlements` re-derives
+  each entitlement from the best surviving grantor (unrefunded, unexpired, or
+  lifetime) instead of blindly deactivating, so a user with overlapping products
+  for one entitlement (a lifetime purchase plus a monthly sub, an iOS sub plus a
+  web sub) keeps access when one expires or is refunded. Matches RevenueCat's
+  `CustomerInfo`, where an entitlement is active if any active product grants
+  it.
 - `TRANSFER` no longer reactivates a refunded or expired entitlement on the
   destination. A revoked lifetime entitlement riding a transfer came out active
   with no expiry, re-granting paid access for free. `transferEntitlements` now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,13 @@
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
-When working on Convex code, **always read `example/convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
+When working on Convex code, **always read
+`example/convex/_generated/ai/guidelines.md` first** for important guidelines on
+how to correctly use Convex APIs and patterns. The file contains rules that
+override what you may have learned about Convex from training data.
 
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+Convex agent skills for common tasks can be installed by running
+`npx convex ai-files install`.
+
 <!-- convex-ai-end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,14 @@ local HTTP endpoint to exercise manually.
   `isActive && (expiresAtMs === undefined || expiresAtMs > now)`. No
   short-circuits on `billingIssueDetectedAt` or any auxiliary flag. Grace is
   folded into `expiresAtMs` by `processBillingIssue` and `syncSubscriber`.
+- `revokeEntitlements` is grantor-aware. There is one entitlement row per
+  `(appUserId, entitlementId)`, so an entitlement is active while any
+  unrefunded, unexpired (or lifetime) subscription still lists it in
+  `entitlementIds`. On `EXPIRATION` or refund it re-derives the entitlement from
+  the best surviving grantor (via `bestActiveGrantor`) rather than setting
+  `isActive: false`. Don't simplify it back to a blind deactivate: that
+  over-revokes when products overlap (e.g. a lifetime purchase plus a monthly
+  sub for the same entitlement).
 - `upsertSubscription` and `grantEntitlements` patches use `?? existing.field`
   for every field that comes from event. `patch({ field: undefined })` removes
   the field. Partial events (UNCANCELLATION, BILLING_ISSUE) would otherwise

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 A Convex component that mirrors RevenueCat subscription state in your own
 database. It ingests every webhook RevenueCat sends and gets the edge cases
 right (cancellation keeps access until expiration, grace periods stay active,
-refunds revoke immediately), so you check entitlements server-side by querying
-it like any other Convex table, with real-time reactivity and no per-request API
-call. Use it alongside the
+refunds revoke immediately, an entitlement stays active while any active product
+still grants it), so you check entitlements server-side by querying it like any
+other Convex table, with real-time reactivity and no per-request API call. Use
+it alongside the
 [RevenueCat SDK](https://www.revenuecat.com/docs/getting-started/installation),
 which still handles purchases client-side.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -77,7 +77,9 @@ export const onDeleted = internalMutation({
 - `onEntitlementDeactivated` fires when an active entitlement transitions to
   not-active. Covers `EXPIRATION`, refund `CANCELLATION`
   (`cancel_reason: "CUSTOMER_SUPPORT"` or `price < 0`), `TRANSFER` off a user,
-  and sync reconciliation.
+  and sync reconciliation. It does not fire when one of several products
+  granting the entitlement expires or is refunded while another still grants it,
+  since the entitlement stays active.
 - `onCustomerDeleted` fires after `deleteCustomer` purges the component-local
   rows for an `appUserId`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,7 +3,9 @@
 [← Back to README](../README.md)
 
 All query methods return empty arrays or `null` for missing users (never throw).
-Lifetime purchases without `expirationAtMs` are always considered active.
+Lifetime purchases without `expirationAtMs` are always considered active. An
+entitlement stays active as long as any active product grants it, so one product
+expiring or being refunded won't drop access another still provides.
 
 | Method                                                              | Returns                             |
 | :------------------------------------------------------------------ | :---------------------------------- |
@@ -84,12 +86,12 @@ keys). Responses carry `RevenueCat-Rate-Limit-Current-Usage` and
   [Security](security.md#audit-log-redaction)).
 - Rate limited at 100 req/min per app. Dedup runs BEFORE the rate-limit check so
   webhook replays (same `event.id`) don't consume the rate budget.
-- Transfer and alias operations cap at 500 source records per user to stay under
-  Convex's per-transaction write budget. A pathological account (more than 500
-  entitlements or subscriptions) throws `TRANSFER_SAFETY_CAP_EXCEEDED` instead
-  of silently corrupting state. `deleteCustomer` (GDPR purge) has no such
-  ceiling: it drains in bounded batches across transactions, so call it from an
-  action.
+- Transfer, alias, and the surviving-grantor scan on `EXPIRATION` or refund cap
+  at 500 records per user to stay under Convex's per-transaction budget. A
+  pathological account (more than 500 entitlements or subscriptions) throws
+  `TRANSFER_SAFETY_CAP_EXCEEDED` instead of silently corrupting state.
+  `deleteCustomer` (GDPR purge) has no such ceiling: it drains in bounded
+  batches across transactions, so call it from an action.
 - `event.id` is capped at 128 bytes. Webhook bodies are capped at 1MB. Both
   reject at the HTTP boundary before any database touch.
 - `event.event_timestamp_ms` is clamped to `now + 5min` on insert so a

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -80,6 +80,13 @@ flowchart LR
     N -->|"no"| F
 ```
 
+An entitlement id can be granted by more than one product (a lifetime purchase
+plus a monthly sub, or the same entitlement on iOS and web). The component keeps
+one entitlement row per `(appUserId, entitlementId)`, and on `EXPIRATION` or
+refund it re-derives that row from the best still-active grantor instead of
+revoking. The entitlement only goes inactive once every product that grants it
+has expired or been refunded, matching RevenueCat's `CustomerInfo`.
+
 ## Derived `willRenew`
 
 `Subscription.autoRenewStatus` is the iOS `EntitlementInfo.willRenew` / Android

--- a/example/README.md
+++ b/example/README.md
@@ -6,16 +6,20 @@ plus a simulator for every webhook the component handles, rendered live.
 
 ## What it shows
 
-- Real purchases of every offering (Monthly, Yearly, Lifetime) through the
-  RevenueCat Web SDK and Test Store. Each fires a real webhook at your
-  deployment over the HTTP path.
-- A simulator that fires every event the component handles (renewal, product
-  change, billing issue, expiration, refund, transfer, redeem, virtual currency,
-  invoice, experiment, and the rest), for the events RevenueCat won't emit on
-  demand.
-- Live reactive panels for entitlement, subscription, grace, customer,
-  virtual-currency, invoice, and recent-webhook state, plus a reset to start
-  from a clean slate.
+Two paths into the component, side by side.
+
+Real purchases run through the RevenueCat Web SDK and Test Store. The Buy
+buttons call `Purchases.purchase()`, RevenueCat records the sandbox purchase and
+sends a real webhook to your `convex.site` endpoint. These are the only actions
+that reach RevenueCat, so they're the only ones on the RC webhook dashboard.
+
+Simulated webhooks cover everything else. The Simulate buttons post a
+RevenueCat-shaped payload straight to the component's `process` mutation,
+bypassing RevenueCat and the HTTP and auth layer. They drive the handler, dedup,
+and state logic, but never reach RevenueCat and never show on the dashboard.
+
+Live reactive panels for entitlement, subscription, grace, customer,
+virtual-currency, invoice, and recent-webhook state update on every action.
 
 ## Structure
 
@@ -74,6 +78,34 @@ npm run test
 
 Open the Vite URL, buy an offering or fire a simulated webhook, and watch the
 panels update live.
+
+## Real vs simulated
+
+RevenueCat only emits events when something real happens, and the web SDK can
+trigger only a couple of them. From this client-only demo:
+
+- Real on a buy: `INITIAL_PURCHASE` (Monthly and Yearly) and
+  `NON_RENEWING_PURCHASE` (Lifetime). The real SDK runs, so RevenueCat sends the
+  webhook and it shows on the RC dashboard.
+- Real on RevenueCat's clock: the Test Store auto-renews and expires test
+  subscriptions on a compressed schedule, so `RENEWAL` and `EXPIRATION` land on
+  their own a few minutes after a buy. Watch the recent-events panel.
+- Simulated, because the client can't trigger them: `@revenuecat/purchases-js`
+  has no product-change method (`PRODUCT_CHANGE`), virtual currency is read-only
+  (`VIRTUAL_CURRENCY_TRANSACTION`), and `changeUser` switches identity without
+  re-attributing a receipt, so it fires no `TRANSFER`. Everything else
+  (`BILLING_ISSUE`, `SUBSCRIPTION_PAUSED`, `CANCELLATION`, `UNCANCELLATION`,
+  `SUBSCRIPTION_EXTENDED`, `INVOICE_ISSUANCE`, refunds,
+  `TEMPORARY_ENTITLEMENT_GRANT`, `EXPERIMENT_ENROLLMENT`, `PURCHASE_REDEEMED`,
+  `TEST`, and the legacy pair) needs a real store condition, a dashboard action,
+  or a server call with a secret key, none of which a client-only showcase can
+  force.
+
+Simulated payloads are RevenueCat-shaped, carrying the same fields a real
+webhook does. They're tagged `environment: "PRODUCTION"` while real Test Store
+events are `SANDBOX`, so you can tell them apart in the `webhookEvents` audit
+table. Handler correctness for every event is covered by the component's own
+suite (`src/component/*.test.ts`). The simulator just shows the flows live.
 
 ## Supported webhook events
 

--- a/example/convex/_generated/ai/ai-files.state.json
+++ b/example/convex/_generated/ai/ai-files.state.json
@@ -1,14 +1,6 @@
 {
   "guidelinesHash": "62d72acb9afcc18f658d88dd772f34b5b1da5fa60ef0402e57a784d97c458e57",
-  "agentsMdSectionHash": "42a9e7357f28f23a7ece5e63084a6c0a5b1dbc150b9f8e5ed046921a470a6320",
-  "claudeMdHash": "42a9e7357f28f23a7ece5e63084a6c0a5b1dbc150b9f8e5ed046921a470a6320",
-  "agentSkillsSha": "8639fef5ec5590f2569dc4e5228f8c996b526334",
-  "installedSkillNames": [
-    "convex",
-    "convex-create-component",
-    "convex-migration-helper",
-    "convex-performance-audit",
-    "convex-quickstart",
-    "convex-setup-auth"
-  ]
+  "agentsMdSectionHash": "063b89d9a59ca099266d54d98a6e2b5fd64552c90f67610cbcf04e2733a52a36",
+  "claudeMdHash": "063b89d9a59ca099266d54d98a6e2b5fd64552c90f67610cbcf04e2733a52a36",
+  "agentSkillsSha": "294d4f05edb5e7b57f3c534b79dd00e8e3d7b60d"
 }

--- a/example/convex/simulate.ts
+++ b/example/convex/simulate.ts
@@ -29,7 +29,12 @@ function buildEvent(
     transaction_id: txn,
     original_transaction_id: txn,
     price: 9.99,
+    price_in_purchased_currency: 9.99,
     currency: "USD",
+    country_code: "US",
+    is_family_share: false,
+    commission_percentage: 0,
+    presented_offering_id: "default",
   };
   switch (scenario) {
     case "INITIAL_PURCHASE":

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -265,6 +265,11 @@ export function App() {
             ))}
           </div>
         )}
+        <div style={{ marginTop: 8, color: "#94a3b8", fontSize: 12 }}>
+          buys fire real INITIAL_PURCHASE and NON_RENEWING_PURCHASE. RC also
+          sends real RENEWAL, EXPIRATION, and INVOICE_ISSUANCE on the Test
+          Store's clock.
+        </div>
       </div>
 
       <div style={{ ...card, marginBottom: 20 }}>
@@ -296,6 +301,17 @@ export function App() {
               {simMsg}
             </span>
           )}
+        </div>
+        <div
+          style={{
+            color: "#94a3b8",
+            fontSize: 11,
+            marginTop: -4,
+            marginBottom: 12,
+          }}
+        >
+          posted straight to the component, bypassing RevenueCat, so they never
+          reach the RC dashboard
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 18 }}>
           {GROUPS.map((g) => (

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,7 @@
       "source": "get-convex/agent-skills",
       "sourceType": "github",
       "skillPath": "skills/convex-migration-helper/SKILL.md",
-      "computedHash": "8da4dee6f36c71b5d899b90ad7bd1d3730cf4dd35118f9ea856075df29809c04"
+      "computedHash": "47ad936c1977eecca736211fe4efb171b53c412b49cffc42267095276a8df36d"
     },
     "convex-performance-audit": {
       "source": "get-convex/agent-skills",

--- a/src/component/handlers.test.ts
+++ b/src/component/handlers.test.ts
@@ -2466,4 +2466,181 @@ describe("handlers", () => {
       );
     });
   });
+
+  describe("multi-product entitlement", () => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const fire = (
+      t: ReturnType<typeof initConvexTest>,
+      p: ReturnType<typeof createEventPayload>,
+    ) =>
+      t.mutation(api.webhooks.process, {
+        event: {
+          id: p.id,
+          type: p.type,
+          app_id: p.app_id,
+          app_user_id: p.app_user_id,
+          environment: p.environment,
+          store: p.store,
+        },
+        payload: p,
+      });
+
+    test("EXPIRATION of one product keeps an entitlement still granted by another active subscription", async () => {
+      const t = initConvexTest();
+      const now = Date.now();
+      const yearlyExp = now + 300 * DAY;
+      const monthlyExp = now + 5 * DAY;
+      const user = "user_multi_grant";
+
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_year",
+          type: "INITIAL_PURCHASE",
+          app_user_id: user,
+          product_id: "yearly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: yearlyExp,
+          original_transaction_id: "otxn_year",
+          transaction_id: "txn_year",
+        }),
+      );
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_month",
+          type: "INITIAL_PURCHASE",
+          app_user_id: user,
+          product_id: "monthly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: monthlyExp,
+          original_transaction_id: "otxn_month",
+          transaction_id: "txn_month",
+        }),
+      );
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_month_exp",
+          type: "EXPIRATION",
+          app_user_id: user,
+          product_id: "monthly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: now - 1,
+          original_transaction_id: "otxn_month",
+          transaction_id: "txn_month",
+        }),
+      );
+
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: user,
+          entitlementId: "premium",
+        }),
+      ).toBe(true);
+
+      const active = await t.query(api.entitlements.getActive, {
+        appUserId: user,
+      });
+      expect(active).toHaveLength(1);
+      expect(active[0].expiresAtMs).toBe(yearlyExp);
+      expect(active[0].productId).toBe("yearly");
+    });
+
+    test("refund of one product keeps an entitlement still granted by another active subscription", async () => {
+      const t = initConvexTest();
+      const now = Date.now();
+      const yearlyExp = now + 300 * DAY;
+      const monthlyExp = now + 5 * DAY;
+      const user = "user_multi_refund";
+
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_year2",
+          type: "INITIAL_PURCHASE",
+          app_user_id: user,
+          product_id: "yearly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: yearlyExp,
+          original_transaction_id: "otxn_year2",
+          transaction_id: "txn_year2",
+        }),
+      );
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_month2",
+          type: "INITIAL_PURCHASE",
+          app_user_id: user,
+          product_id: "monthly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: monthlyExp,
+          original_transaction_id: "otxn_month2",
+          transaction_id: "txn_month2",
+        }),
+      );
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_month_refund",
+          type: "CANCELLATION",
+          app_user_id: user,
+          product_id: "monthly",
+          cancel_reason: "CUSTOMER_SUPPORT",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: monthlyExp,
+          original_transaction_id: "otxn_month2",
+          transaction_id: "txn_month2",
+        }),
+      );
+
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: user,
+          entitlementId: "premium",
+        }),
+      ).toBe(true);
+    });
+
+    test("EXPIRATION of the only granting product still revokes", async () => {
+      const t = initConvexTest();
+      const now = Date.now();
+      const user = "user_single_grant";
+
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_only",
+          type: "INITIAL_PURCHASE",
+          app_user_id: user,
+          product_id: "monthly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: now + 5 * DAY,
+          original_transaction_id: "otxn_only",
+          transaction_id: "txn_only",
+        }),
+      );
+      await fire(
+        t,
+        createEventPayload({
+          id: "evt_only_exp",
+          type: "EXPIRATION",
+          app_user_id: user,
+          product_id: "monthly",
+          entitlement_ids: ["premium"],
+          expiration_at_ms: now - 1,
+          original_transaction_id: "otxn_only",
+          transaction_id: "txn_only",
+        }),
+      );
+
+      expect(
+        await t.query(api.entitlements.check, {
+          appUserId: user,
+          entitlementId: "premium",
+        }),
+      ).toBe(false);
+    });
+  });
 });

--- a/src/component/handlers.ts
+++ b/src/component/handlers.ts
@@ -1,7 +1,7 @@
 import { v, ConvexError, type Infer } from "convex/values";
 import type { GenericMutationCtx } from "convex/server";
 import { internalMutation } from "./_generated/server.js";
-import type { DataModel } from "./_generated/dataModel.js";
+import type { DataModel, Doc } from "./_generated/dataModel.js";
 import {
   environmentValidator,
   ownershipTypeValidator,
@@ -463,14 +463,46 @@ async function grantEntitlements(
   }
 }
 
+function bestActiveGrantor(
+  subs: Doc<"subscriptions">[],
+  entitlementId: string,
+  now: number,
+  excludeOriginalTransactionId?: string,
+): Doc<"subscriptions"> | null {
+  let best: Doc<"subscriptions"> | null = null;
+  for (const sub of subs) {
+    if (sub.originalTransactionId === excludeOriginalTransactionId) continue;
+    if (sub.refundedAtMs) continue;
+    if (!sub.entitlementIds?.includes(entitlementId)) continue;
+    if (sub.expirationAtMs !== undefined && sub.expirationAtMs <= now) continue;
+    if (best === null) {
+      best = sub;
+    } else if (best.expirationAtMs !== undefined) {
+      if (
+        sub.expirationAtMs === undefined ||
+        sub.expirationAtMs > best.expirationAtMs
+      ) {
+        best = sub;
+      }
+    }
+  }
+  return best;
+}
+
 async function revokeEntitlements(
   ctx: MutationCtx,
   appUserId: string,
   entitlementIds?: string[],
+  excludeOriginalTransactionId?: string,
 ): Promise<void> {
   const now = Date.now();
 
   if (entitlementIds?.length) {
+    const subs = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_app_user", (q) => q.eq("appUserId", appUserId))
+      .take(TRANSFER_SAFETY_CAP + 1);
+    assertUnderCap(subs, "revokeEntitlements", appUserId);
     for (const entitlementId of entitlementIds) {
       const ent = await ctx.db
         .query("entitlements")
@@ -478,7 +510,24 @@ async function revokeEntitlements(
           q.eq("appUserId", appUserId).eq("entitlementId", entitlementId),
         )
         .first();
-      if (ent && ent.isActive) {
+      if (!ent || !ent.isActive) continue;
+      const grantor = bestActiveGrantor(
+        subs,
+        entitlementId,
+        now,
+        excludeOriginalTransactionId,
+      );
+      if (grantor) {
+        await ctx.db.patch(ent._id, {
+          isActive: true,
+          expiresAtMs: grantor.expirationAtMs,
+          productId: grantor.productId,
+          store: grantor.store,
+          ownershipType: grantor.ownershipType ?? ent.ownershipType,
+          billingIssueDetectedAt: undefined,
+          updatedAt: now,
+        });
+      } else {
         await ctx.db.patch(ent._id, {
           isActive: false,
           billingIssueDetectedAt: undefined,
@@ -736,7 +785,12 @@ export const processCancellation = internalMutation({
 
     const entitlementIds = getEntitlementIds(event);
     if (isRefund && event.app_user_id && entitlementIds?.length) {
-      await revokeEntitlements(ctx, event.app_user_id, entitlementIds);
+      await revokeEntitlements(
+        ctx,
+        event.app_user_id,
+        entitlementIds,
+        event.original_transaction_id,
+      );
     }
     return null;
   },
@@ -771,7 +825,12 @@ export const processExpiration = internalMutation({
     });
     const entitlementIds = getEntitlementIds(event);
     if (event.app_user_id && entitlementIds?.length) {
-      await revokeEntitlements(ctx, event.app_user_id, entitlementIds);
+      await revokeEntitlements(
+        ctx,
+        event.app_user_id,
+        entitlementIds,
+        event.original_transaction_id,
+      );
     }
     return null;
   },
@@ -1104,7 +1163,12 @@ export const processRefund = internalMutation({
     });
     const entitlementIds = getEntitlementIds(event);
     if (event.app_user_id && entitlementIds?.length) {
-      await revokeEntitlements(ctx, event.app_user_id, entitlementIds);
+      await revokeEntitlements(
+        ctx,
+        event.app_user_id,
+        entitlementIds,
+        event.original_transaction_id,
+      );
     }
     return null;
   },


### PR DESCRIPTION
Stop `EXPIRATION` and refund `CANCELLATION` from revoking an entitlement that a different active subscription still grants. When two products grant the same entitlement id (a lifetime purchase plus a monthly sub, an iOS sub plus a web sub), expiring or refunding one wrongly revoked the shared entitlement until the other renewed, dropping paid access. `revokeEntitlements` now excludes the expiring transaction and re-derives the entitlement from the best surviving grantor (unrefunded, unexpired, or lifetime), matching RevenueCat's `CustomerInfo`. Folded into the unreleased `0.3.2`, no version bump.

- `handlers.ts`: add `bestActiveGrantor`, make `revokeEntitlements` grantor-aware, pass the expiring `original_transaction_id` from `EXPIRATION`, refund `CANCELLATION`, and legacy `REFUND`
- `handlers.test.ts`: cover multi-product expiration keep, multi-product refund keep, and single-grantor still-revokes
- `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`, `docs/webhooks.md`: record the fix, the grantor-aware revoke invariant, and the multi-product access-check behavior
- `example/`: enrich simulator payloads with real RevenueCat fields, label real vs simulated webhooks, document the split
- `AGENTS.md`, `CLAUDE.md`, `skills-lock.json`: resync from `npx convex ai-files install`